### PR TITLE
fix slack notification logic, improve message

### DIFF
--- a/foodsaving/stores/models.py
+++ b/foodsaving/stores/models.py
@@ -3,6 +3,7 @@ from itertools import zip_longest
 import dateutil.rrule
 import requests
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db import transaction
@@ -10,7 +11,6 @@ from django.db.models import Count
 from django.template.loader import render_to_string
 from django.utils import timezone
 
-from django.conf import settings
 from foodsaving.base.base_models import BaseModel, LocationModel
 from foodsaving.stores.signals import pickup_done, pickup_missed
 
@@ -203,20 +203,26 @@ class PickupDate(BaseModel):
     def __str__(self):
         return '{} - {}'.format(self.date, self.store)
 
-    def notify_upcoming(self):
-        if 'upcoming' not in self.notifications_sent and self.store.group.slack_webhook != '':
-            context = {
-                'store_name': self.store.name,
-                'number_of_hours': self.store.upcoming_notification_hours,
-                'store_page_url': '{hostname}/#!/group/{groupid}/store/{storeid}/pickups'
+    def notify_upcoming_via_slack(self):
+        if 'upcoming' not in self.notifications_sent:
+            store_page_url = '{hostname}/#!/group/{groupid}/store/{storeid}/pickups'\
                 .format(hostname=settings.HOSTNAME,
                         groupid=self.store.group.id,
                         storeid=self.store.id)
-            }
             r = requests.post(self.store.group.slack_webhook, json={
-                'text': render_to_string('upcoming_pickup_slack.jinja', context),
                 'username': self.store.group.name,
-                'icon_url': '{hostname}/app/icon/carrot_logo.png'.format(hostname=settings.HOSTNAME)
+                'icon_url': '{hostname}/app/icon/carrot_logo.png'.format(hostname=settings.HOSTNAME),
+                'attachments': [
+                    {
+                        'title': self.store.name,
+                        'title_link': store_page_url,
+                        'text': render_to_string('upcoming_pickup_slack.jinja', {
+                            'number_of_hours': self.store.upcoming_notification_hours,
+                            'store_page_url': store_page_url
+                        }),
+                        'color': 'warning'
+                    }
+                ]
             })
             self.notifications_sent['upcoming'] = {'status': r.status_code, 'data': r.text}
             self.save()

--- a/foodsaving/stores/templates/upcoming_pickup_slack.jinja
+++ b/foodsaving/stores/templates/upcoming_pickup_slack.jinja
@@ -1,1 +1,1 @@
-{% trans %}Food pickup at *{{ store_name }}* in {{ number_of_hours }} hours! <{{ store_page_url }}|Click here> and save the food!{% endtrans %}
+{% trans %}Food pick-up in {{ number_of_hours }} hours, <{{ store_page_url }}|click here> and save the food!{% endtrans %}

--- a/foodsaving/stores/tests/test_notifications.py
+++ b/foodsaving/stores/tests/test_notifications.py
@@ -10,11 +10,14 @@ from foodsaving.stores.factories import StoreFactory, PickupDateFactory
 from foodsaving.users.factories import UserFactory
 
 
-class TestNotifications(APITestCase):
+def parse(body):
+    return json.loads(body, encoding='utf-8')
+
+
+class TestNotificationsDisabled(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
         cls.member = UserFactory()
         cls.group = GroupFactory(members=[cls.member, ])
         cls.store = StoreFactory(group=cls.group)
@@ -22,22 +25,44 @@ class TestNotifications(APITestCase):
 
     @responses.activate
     def test_send_no_upcoming_notification_if_no_webhook(self):
-        self.pickup.notify_upcoming()
+        self.group.send_notifications()
+
+
+class TestNotificationsEnabled(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.member = UserFactory()
+        cls.group = GroupFactory(members=[cls.member, ], slack_webhook='https://hooks.slack.com/services/some_webhook')
+        cls.store = StoreFactory(group=cls.group, name="Elke's")
+        cls.pickup_upcoming = PickupDateFactory(store=cls.store, date=timezone.now() + relativedelta(hours=1))
+        cls.pickup_future = PickupDateFactory(store=cls.store, date=timezone.now() + relativedelta(hours=12))
+        cls.pickup_past = PickupDateFactory(store=cls.store, date=timezone.now() - relativedelta(days=1))
+
+    def refresh(self):
+        for p in (
+            self.pickup_upcoming,
+            self.pickup_future,
+            self.pickup_past
+        ):
+            p.refresh_from_db()
 
     @responses.activate
     def test_send_upcoming_notification(self):
-        responses.add(responses.POST, 'https://example.com/test', body='ok')
-        self.pickup.date = timezone.now() + relativedelta(hours=1)
-        self.pickup.save()
-        self.group.slack_webhook = 'https://example.com/test'
-        self.group.save()
-        self.pickup.notify_upcoming()
+        responses.add(responses.POST, 'https://hooks.slack.com/services/some_webhook', body='ok')
+        self.group.send_notifications()
+        self.refresh()
         self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(self.pickup.notifications_sent['upcoming'], {'status': 200, 'data': 'ok'})
-        self.assertTrue('Food pickup at' in json.loads(responses.calls[0].request.body.decode('utf8'))['text'])
+        self.assertEqual(
+            self.pickup_upcoming.notifications_sent.get('upcoming'),
+            {'status': 200, 'data': 'ok'},
+        )
+        slack_request = parse(responses.calls[0].request.body)
+        self.assertIn('Food pick-up in', slack_request['attachments'][0]['text'])
+        self.assertIn("Elke's", slack_request['attachments'][0]['title'])
 
         # should not send a second notification
-        self.pickup.notify_upcoming()
+        self.group.send_notifications()
         self.assertEqual(len(responses.calls), 1)
 
 

--- a/foodsaving/stores/tests/test_notifications.py
+++ b/foodsaving/stores/tests/test_notifications.py
@@ -11,7 +11,7 @@ from foodsaving.users.factories import UserFactory
 
 
 def parse(body):
-    return json.loads(body, encoding='utf-8')
+    return json.loads(body.decode('utf-8'))
 
 
 class TestNotificationsDisabled(APITestCase):


### PR DESCRIPTION
By sending attachments, we don't need to rely on Slack's mrkdwn formatting and don't need to escape '*_~' in user-provided values