### PR TITLE
enable pagination for listing messages

### DIFF
--- a/foodsaving/conversations/api.py
+++ b/foodsaving/conversations/api.py
@@ -1,5 +1,6 @@
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import mixins
+from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated, BasePermission
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -12,6 +13,12 @@ from foodsaving.conversations.serializers import (
     ConversationSerializer,
     ConversationMessageSerializer
 )
+
+
+class MessagePagination(CursorPagination):
+    # TODO: create an index on 'created_at' for increased speed
+    page_size = 50
+    ordering = '-created_at'
 
 
 class IsConversationParticipant(BasePermission):
@@ -40,14 +47,11 @@ class ConversationMessageViewSet(
     ConversationMessages
     """
 
-    # TODO: sort by newest first (reverse id)
-    # TODO: limit to 50 or so
-    # TODO: to load older messages add "before" that does a "where id < before"
-
     queryset = ConversationMessage.objects
     serializer_class = ConversationMessageSerializer
     permission_classes = (IsAuthenticated, IsConversationParticipant)
     filter_fields = ('conversation',)
+    pagination_class = MessagePagination
 
     def get_queryset(self):
         return self.queryset.filter(conversation__participants=self.request.user)

--- a/foodsaving/conversations/tests/test_api.py
+++ b/foodsaving/conversations/tests/test_api.py
@@ -32,16 +32,16 @@ class TestConversationsAPI(APITestCase):
         self.client.force_login(user=self.participant1)
         response = self.client.get('/api/messages/?conversation={}'.format(self.conversation1.id), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['content'], 'hello')
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['content'], 'hello')
 
     def test_can_get_messages_for_all_conversations(self):
         self.client.force_login(user=self.participant1)
         response = self.client.get('/api/messages/', format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]['content'], 'hello')
-        self.assertEqual(response.data[1]['content'], 'hello2')
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['results'][0]['content'], 'hello2')
+        self.assertEqual(response.data['results'][1]['content'], 'hello')
 
     def test_cannot_get_messages_if_not_in_conversation(self):
         self.client.force_login(user=self.participant1)


### PR DESCRIPTION
Uses an opaque cursor provided by DRF: http://www.django-rest-framework.org/api-guide/pagination/#cursorpagination

Needs frontend changes at karrot/quasar