### PR TITLE
Add token authentication

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = (
     'django_extensions',
     'corsheaders',
     'rest_framework',
+    'rest_framework.authtoken',
     'rest_framework_nested',
     'rest_framework_swagger',
     'anymail',
@@ -62,7 +63,11 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
-    )
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
 }
 
 MIDDLEWARE_CLASSES = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -65,8 +65,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ),
 }
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework_nested import routers
 from rest_framework_swagger.views import get_swagger_view
 
@@ -63,6 +64,7 @@ router.register('invitations', InvitationAcceptViewSet)
 router.register(r'feedback', FeedbackViewSet)
 
 urlpatterns = [
+    url(r'^api/auth/token/', obtain_auth_token),
     url(r'^api/', include(router.urls, namespace='api')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^admin/', include(admin.site.urls)),


### PR DESCRIPTION
Uses DRF token authentication. To be used for auth on mobile clients, or API, etc... not for browser use.