### PR TITLE
add group-info endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -21,7 +21,7 @@ from rest_framework_nested import routers
 from rest_framework_swagger.views import get_swagger_view
 
 from foodsaving.conversations.api import ConversationMessageViewSet
-from foodsaving.groups.api import GroupViewSet, AgreementViewSet
+from foodsaving.groups.api import GroupViewSet, AgreementViewSet, GroupInfoViewSet
 from foodsaving.history.api import HistoryViewSet
 from foodsaving.invitations.api import InvitationsViewSet, InvitationAcceptViewSet
 from foodsaving.stores.api import StoreViewSet, PickupDateViewSet, PickupDateSeriesViewSet, FeedbackViewSet
@@ -32,6 +32,7 @@ from foodsaving.users.api import UserViewSet
 router = routers.DefaultRouter()
 
 router.register(r'groups', GroupViewSet)
+router.register(r'groups-info', GroupInfoViewSet)
 router.register(r'agreements', AgreementViewSet)
 router.register(r'auth', AuthViewSet, base_name='auth')
 

--- a/foodsaving/groups/api.py
+++ b/foodsaving/groups/api.py
@@ -43,6 +43,26 @@ class CanUpdateMemberships(BasePermission):
         return obj.group.is_member_with_role(request.user, roles.GROUP_MEMBERSHIP_MANAGER)
 
 
+class GroupInfoViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    GenericViewSet
+):
+    """
+    Group Info - public information
+
+    # Query parameters
+    - `?members` - filter by member user id
+    - `?search` - search in name and public description
+    - `?include_empty` - set to False to exclude empty groups without members
+    """
+    queryset = GroupModel.objects
+    filter_backends = (SearchFilter, DjangoFilterBackend)
+    filter_class = GroupsFilter
+    search_fields = ('name', 'public_description')
+    serializer_class = GroupPreviewSerializer
+
+
 class GroupViewSet(
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
@@ -52,7 +72,7 @@ class GroupViewSet(
     GenericViewSet
 ):
     """
-    Groups
+    Group Detail - in future only for members
 
     # Query parameters
     - `?members` - filter by member user id

--- a/foodsaving/groups/tests/test_api.py
+++ b/foodsaving/groups/tests/test_api.py
@@ -11,6 +11,53 @@ from foodsaving.users.factories import UserFactory
 from foodsaving.utils.tests.fake import faker
 
 
+class TestGroupsInfoAPI(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory()
+        cls.member = UserFactory()
+        cls.group = GroupFactory(members=[cls.member, ])
+        cls.url = '/api/groups-info/'
+
+    def test_list_groups_as_anon(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+    def test_list_groups_as_user(self):
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+    def test_list_groups_as_member(self):
+        self.client.force_login(user=self.member)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+    def test_retrieve_group_as_anon(self):
+        url = self.url + str(self.group.id) + '/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+    def test_retrieve_group_as_user(self):
+        self.client.force_login(user=self.user)
+        url = self.url + str(self.group.id) + '/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+    def test_retrieve_group_as_member(self):
+        self.client.force_login(user=self.member)
+        url = self.url + str(self.group.id) + '/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse('password' in response.data)
+
+
 class TestGroupsAPI(APITestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This is part one of the process to make the groups endpoint more sane.
Part two will disable the access to `/api/groups/:groupId/` for non-members (except for joining a group maybe?)