### PR TITLE
Support websocket auth using token

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -189,6 +189,8 @@ CHANNEL_LAYERS = {
     },
 }
 
+CHANNELS_WS_PROTOCOLS = ['karrot.token']
+
 # NB: Keep this as the last line, and keep
 # local_settings.py out of version control
 try:

--- a/foodsaving/subscriptions/consumers.py
+++ b/foodsaving/subscriptions/consumers.py
@@ -1,7 +1,37 @@
+from base64 import b64decode
+from urllib.parse import unquote
+
 from channels.generic.websockets import JsonWebsocketConsumer
 from django.utils import timezone
+from rest_framework.authentication import TokenAuthentication
 
 from foodsaving.subscriptions.models import ChannelSubscription
+
+token_auth = TokenAuthentication()
+
+
+def check_for_auth_token_header(message):
+    prefix = 'karrot.token.value.'
+    for header, value in message['headers']:
+        if header == b'sec-websocket-protocol':
+            protocols = [x.strip() for x in unquote(value.decode('ascii')).split(",")]
+            for protocol in protocols:
+                if protocol.startswith(prefix):
+                    value = protocol[len(prefix):]
+                    if len(value) % 4:
+                        # not a multiple of 4, add padding:
+                        value += '=' * (4 - len(value) % 4)
+                    token = b64decode(value).decode('ascii')
+                    message.channel_session['auth_token'] = token
+
+
+def check_for_token_user(message):
+    if not message.user or message.user.is_anonymous():
+        auth_token = message.channel_session.get('auth_token', None)
+        if auth_token:
+            user, _ = token_auth.authenticate_credentials(auth_token)
+            if user:
+                message.user = user
 
 
 class Consumer(JsonWebsocketConsumer):
@@ -9,6 +39,8 @@ class Consumer(JsonWebsocketConsumer):
 
     def connect(self, message, **kwargs):
         """The user has connected! Register their channel subscription."""
+        check_for_auth_token_header(message)
+        check_for_token_user(message)
         user = message.user
         if not user.is_anonymous():
             ChannelSubscription.objects.create(user=user, reply_channel=message.reply_channel)
@@ -16,16 +48,17 @@ class Consumer(JsonWebsocketConsumer):
 
     def receive(self, content, **kwargs):
         """They sent us a websocket message!"""
+        check_for_token_user(self.message)
         user = self.message.user
         if not user.is_anonymous():
             reply_channel = self.message.reply_channel.name
             subscriptions = ChannelSubscription.objects.filter(user=user, reply_channel=reply_channel)
             update_attrs = {'lastseen_at': timezone.now()}
-            if 'type' in content:
-                if content['type'] == 'away':
-                    update_attrs['away_at'] = timezone.now()
-                elif content['type'] == 'back':
-                    update_attrs['away_at'] = None
+            type = content.get('type', None)
+            if type == 'away':
+                update_attrs['away_at'] = timezone.now()
+            elif type == 'back':
+                update_attrs['away_at'] = None
             subscriptions.update(**update_attrs)
 
     def disconnect(self, message, **kwargs):

--- a/foodsaving/subscriptions/receivers.py
+++ b/foodsaving/subscriptions/receivers.py
@@ -25,8 +25,9 @@ def send_messages(sender, instance, **kwargs):
 
     for subscription in ChannelSubscription.objects.filter(user__in=conversation.participants.all()):
 
-        if not subscription.away_at:
-            push_exclude_users.append(subscription.user)
+        # TODO: add back in once https://github.com/yunity/karrot-frontend/issues/770 is implemented
+        # if not subscription.away_at:
+        #     push_exclude_users.append(subscription.user)
 
         Channel(subscription.reply_channel).send({
             "text": json.dumps({
@@ -42,10 +43,10 @@ def send_messages(sender, instance, **kwargs):
 
     notify_multiple_devices(
         registration_ids=tokens,
-        message_title=message.content,
+        message_title=f'{message.author.display_name}: {message.content}',
         # this causes each notification for a given conversation to replace previous notifications so they don't build
         # up too much. fancier would be to make the new notifications show a summary not just the latest message.
-        tag='conversation:{}'.format(conversation.id)
+        tag=f'conversation:{conversation.id}'
     )
 
 
@@ -57,7 +58,6 @@ def remove_participant(sender, instance, **kwargs):
     conversation = instance.conversation
     for item in ChannelSubscription.objects.filter(user=user):
         Channel(item.reply_channel).send({
-            # TODO: use a serializer
             'text': json.dumps({
                 'topic': 'conversations:leave',
                 'payload': {

--- a/foodsaving/subscriptions/receivers.py
+++ b/foodsaving/subscriptions/receivers.py
@@ -43,10 +43,10 @@ def send_messages(sender, instance, **kwargs):
 
     notify_multiple_devices(
         registration_ids=tokens,
-        message_title=f'{message.author.display_name}: {message.content}',
+        message_title='{}: {}'.format(message.author.display_name, message.content),
         # this causes each notification for a given conversation to replace previous notifications so they don't build
         # up too much. fancier would be to make the new notifications show a summary not just the latest message.
-        tag=f'conversation:{conversation.id}'
+        tag='conversation:{}'.format(conversation.id)
     )
 
 

--- a/foodsaving/subscriptions/tests/test_consumers.py
+++ b/foodsaving/subscriptions/tests/test_consumers.py
@@ -94,6 +94,15 @@ class TokenUtilTests(TestCase):
     def test_check_for_auth_token_header(self):
         message = TestMessage({
             'headers': [
+                [b'sec-websocket-protocol', b'karrot.token,karrot.token.value.Zm9v']
+            ]
+        })
+        check_for_auth_token_header(message)
+        self.assertEqual(message.channel_session['auth_token'], 'foo')
+
+    def test_check_for_auth_token_header_with_removed_base64_padding(self):
+        message = TestMessage({
+            'headers': [
                 [b'sec-websocket-protocol', b'karrot.token,karrot.token.value.Zm9vMQ']
             ]
         })

--- a/foodsaving/subscriptions/tests/test_consumers.py
+++ b/foodsaving/subscriptions/tests/test_consumers.py
@@ -1,8 +1,11 @@
 from channels import Channel
 from channels.test import ChannelTestCase, WSClient
 from dateutil.relativedelta import relativedelta
+from django.test import TestCase
 from django.utils import timezone
+from rest_framework.authtoken.models import Token
 
+from foodsaving.subscriptions.consumers import check_for_auth_token_header, check_for_token_user
 from foodsaving.subscriptions.models import ChannelSubscription
 from foodsaving.users.factories import UserFactory
 
@@ -74,3 +77,33 @@ class ConsumerTests(ChannelTestCase):
 
         client.send_and_consume('websocket.disconnect', path='/')
         self.assertEqual(ChannelSubscription.objects.filter(user=user).count(), 0, 'Did not remove subscription')
+
+
+class TestMessage(dict):
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+        self.session = {}
+        self.user = None
+
+    @property
+    def channel_session(self):
+        return self.session
+
+
+class TokenUtilTests(TestCase):
+    def test_check_for_auth_token_header(self):
+        message = TestMessage({
+            'headers': [
+                [b'sec-websocket-protocol', b'karrot.token,karrot.token.value.Zm9v']
+            ]
+        })
+        check_for_auth_token_header(message)
+        self.assertEqual(message.channel_session['auth_token'], 'foo')
+
+    def test_check_for_token_user(self):
+        user = UserFactory()
+        token = Token.objects.create(user=user)
+        message = TestMessage()
+        message.channel_session['auth_token'] = token.key
+        check_for_token_user(message)
+        self.assertEqual(message.user, user)

--- a/foodsaving/subscriptions/tests/test_consumers.py
+++ b/foodsaving/subscriptions/tests/test_consumers.py
@@ -94,11 +94,11 @@ class TokenUtilTests(TestCase):
     def test_check_for_auth_token_header(self):
         message = TestMessage({
             'headers': [
-                [b'sec-websocket-protocol', b'karrot.token,karrot.token.value.Zm9v']
+                [b'sec-websocket-protocol', b'karrot.token,karrot.token.value.Zm9vMQ']
             ]
         })
         check_for_auth_token_header(message)
-        self.assertEqual(message.channel_session['auth_token'], 'foo')
+        self.assertEqual(message.channel_session['auth_token'], 'foo1')
 
     def test_check_for_token_user(self):
         user = UserFactory()

--- a/foodsaving/subscriptions/tests/test_receivers.py
+++ b/foodsaving/subscriptions/tests/test_receivers.py
@@ -87,7 +87,7 @@ class ReceiverPushTests(ChannelTestCase):
     def test_sends_to_push_subscribers(self, m):
         def check_json_data(request):
             data = json.loads(request.body.decode('utf-8'))
-            self.assertEqual(data['notification']['title'], f'{self.author.display_name}: {self.content}')
+            self.assertEqual(data['notification']['title'], '{}: {}'.format(self.author.display_name, self.content))
             self.assertEqual(data['to'], self.token)
             return True
 
@@ -109,7 +109,7 @@ class ReceiverPushTests(ChannelTestCase):
     def test_send_push_notification_if_channel_subscription_is_away(self, m):
         def check_json_data(request):
             data = json.loads(request.body.decode('utf-8'))
-            self.assertEqual(data['notification']['title'], f'{self.author.display_name}: {self.content}')
+            self.assertEqual(data['notification']['title'], '{}: {}'.format(self.author.display_name, self.content))
             self.assertEqual(data['to'], self.token)
             return True
 

--- a/foodsaving/subscriptions/tests/test_receivers.py
+++ b/foodsaving/subscriptions/tests/test_receivers.py
@@ -87,7 +87,7 @@ class ReceiverPushTests(ChannelTestCase):
     def test_sends_to_push_subscribers(self, m):
         def check_json_data(request):
             data = json.loads(request.body.decode('utf-8'))
-            self.assertEqual(data['notification']['title'], self.content)
+            self.assertEqual(data['notification']['title'], f'{self.author.display_name}: {self.content}')
             self.assertEqual(data['to'], self.token)
             return True
 
@@ -96,19 +96,20 @@ class ReceiverPushTests(ChannelTestCase):
         # add a message to the conversation
         ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
 
-    def test_does_not_send_push_notification_if_active_channel_subscription(self, m):
-        # add a channel subscription to prevent the push being sent
-        ChannelSubscription.objects.create(user=self.user, reply_channel='foo')
-
-        # add a message to the conversation
-        ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
-
-        # if it sent a push message, the requests mock would complain there is no matching request...
+    # TODO: add back in once https://github.com/yunity/karrot-frontend/issues/770 is implemented
+    # def test_does_not_send_push_notification_if_active_channel_subscription(self, m):
+    #     # add a channel subscription to prevent the push being sent
+    #     ChannelSubscription.objects.create(user=self.user, reply_channel='foo')
+    #
+    #     # add a message to the conversation
+    #     ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
+    #
+    #     # if it sent a push message, the requests mock would complain there is no matching request...
 
     def test_send_push_notification_if_channel_subscription_is_away(self, m):
         def check_json_data(request):
             data = json.loads(request.body.decode('utf-8'))
-            self.assertEqual(data['notification']['title'], self.content)
+            self.assertEqual(data['notification']['title'], f'{self.author.display_name}: {self.content}')
             self.assertEqual(data['to'], self.token)
             return True
 


### PR DESCRIPTION
Seems a better approach is (ab)using websocket subprotocols to pass the token, some other people doing that:

- https://stackoverflow.com/a/35108078
- https://trello.com/c/lRdCiGzd/1026-2-authenticate-websocket-api-requests-using-subprotocols-not-query-parameters
- https://stackoverflow.com/questions/36323743/oauth2-authentication-for-websockets-pass-bearer-token-via-subprotocols

This is all because you cannot set custom headers for websocket connections, only use this protocol argument (`new WebSocket(url, protocols)`), or query params on the url.

It works like this:
- frontend passes two security protocol entries:
  1. `karrot.token`
  2. `karrot.token.value.<base64token>` *
- backend accepts `karrot.token` as a valid protocol (via `CHANNELS_WS_PROTOCOLS` option)
- when a websocket connection comes in pull the token out from the second header
- we authenticate the user, but also set the token on the channels session
- during a subsequent websocket request we get the token and authenticate again
- if no protocols are set, then the session based auth still works as it did before

\* _base64 padding (`=` at the end) was not accepted as a valid ws protocol value by chrome, so I stripped them out, and added them back in on the server, a bit hacky, but means we can support any token, although our current tokens would be fine as they are I think, so could remove this base64 stuff_

Logout will not clear the channels session, I think it will stay around as long as the socket is open. Our client will disconnect the websocket on logout.

Fixes #439 