### PR TITLE
Add proxy-headers and ws-protocols daphne systemd

### DIFF
--- a/server-configs/templates/daphne.service.j2
+++ b/server-configs/templates/daphne.service.j2
@@ -10,6 +10,8 @@ WorkingDirectory=/var/www/{{ name }}/www
 ExecStart=/var/www/{{ name }}/www/env/bin/daphne \
 	-u /tmp/{{ name }}.sock \
 	--root-path=/var/www/{{ name }}/www \
+	--ws-protocol karrot.token \
+	--proxy-headers \
 	config.asgi:channel_layer
 Restart=always
 


### PR DESCRIPTION
Daphne does not read CHANNELS_WS_PROTOCOLS the from settings file when run standalone, so we have to specify it here.

Proxy headers was set on the server, but missed out here.