### PR TITLE
Add error_code to response

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -68,6 +68,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
     ),
+    'EXCEPTION_HANDLER': 'foodsaving.utils.misc.custom_exception_handler'
 }
 
 MIDDLEWARE_CLASSES = (

--- a/foodsaving/stores/tests/test_pickupdates_api.py
+++ b/foodsaving/stores/tests/test_pickupdates_api.py
@@ -623,7 +623,7 @@ class TestPickupDatesAPI(APITestCase):
         self.pickup.collectors.add(u2)
         response = self.client.post(self.join_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
-        self.assertEqual(response.data, {'detail': 'Pickup date is already full.'})
+        self.assertEqual(response.data['detail'], 'Pickup date is already full.')
 
     def test_join_past_pickup_fails(self):
         self.client.force_login(user=self.member)

--- a/foodsaving/users/tests/test_api.py
+++ b/foodsaving/users/tests/test_api.py
@@ -338,7 +338,7 @@ class TestEMailVerification(APITestCase):
     def test_verify_mail_fails_if_already_verified(self):
         self.client.force_login(user=self.verified_user)
         response = self.client.post(self.url, {'key': self.user.activation_key})
-        self.assertEqual(response.data, {'detail': 'Mail is already verified.'})
+        self.assertEqual(response.data['detail'], 'Mail is already verified.')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_verify_mail_fails_without_key(self):

--- a/foodsaving/utils/misc.py
+++ b/foodsaving/utils/misc.py
@@ -1,5 +1,7 @@
 from json import dumps as dump_json
 
+from rest_framework.views import exception_handler
+
 
 def json_stringify(data):
     """
@@ -7,3 +9,14 @@ def json_stringify(data):
     :rtype: str
     """
     return dump_json(data, sort_keys=True, separators=(',', ':')).encode("utf-8") if data else None
+
+
+def custom_exception_handler(exc, context):
+    # get the standard response first
+    response = exception_handler(exc, context)
+
+    # add in the error code so we can distinguish better in the frontend
+    if 'detail' in response.data and hasattr(exc, 'default_code'):
+        response.data['error_code'] = exc.default_code
+
+    return response

--- a/foodsaving/utils/tests/test_exception_handler.py
+++ b/foodsaving/utils/tests/test_exception_handler.py
@@ -1,8 +1,5 @@
 from rest_framework import status
-from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
-
-from foodsaving.users.factories import UserFactory
 
 
 class TestCustomExceptionHandlerAPI(APITestCase):

--- a/foodsaving/utils/tests/test_exception_handler.py
+++ b/foodsaving/utils/tests/test_exception_handler.py
@@ -1,0 +1,19 @@
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from foodsaving.users.factories import UserFactory
+
+
+class TestCustomExceptionHandlerAPI(APITestCase):
+    def test_use_token(self):
+        response = self.client.get(
+            '/api/auth/status/',
+            **{
+                'HTTP_AUTHORIZATION': 'Token {}'.format('invalidtoken'),
+                'HTTP_ACCEPT_LANGUAGE': 'de',
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['detail'], 'Ungültiges Token')
+        self.assertEqual(response.data['error_code'], 'authentication_failed')


### PR DESCRIPTION
Adds more detail to exception responses if available.

The `default_code` is set on lots of the drf exception classes, see:

```python
class AuthenticationFailed(APIException):
    status_code = status.HTTP_401_UNAUTHORIZED
    default_detail = _('Incorrect authentication credentials.')
    default_code = 'authentication_failed'


class NotAuthenticated(APIException):
    status_code = status.HTTP_401_UNAUTHORIZED
    default_detail = _('Authentication credentials were not provided.')
    default_code = 'not_authenticated'
```

.. but it is not returned, only the status code and the translated message, which means the frontend cannot distinguish them, this PR includes the value specified in the `default_code` and makes it available as `error_code` in the response data.

A curl example:

```
 curl -s -H 'Accept-Language: de'  -XPOST -H 'Authorization: TOKEN foo' localhost:8000/api/auth/user/ | jq .
{
  "detail": "Ungültiges Token",
  "error_code": "authentication_failed"
}
```