### PR TITLE
Fix local settings example logging config

### DIFF
--- a/config/local_settings.py.example
+++ b/config/local_settings.py.example
@@ -93,6 +93,12 @@ FCM_SERVER_KEY = 'your server key'
 #    'release': raven.fetch_git_sha(os.path.dirname(os.pardir)),
 #}
 
+######
+# Logger configuration proposal:
+# Disables most console logging as well as django admin email logging
+# and sends all errors to sentry.
+######
+
 #LOGGING = {
 #    'version': 1,
 #    'disable_existing_loggers': False,
@@ -115,10 +121,6 @@ FCM_SERVER_KEY = 'your server key'
 #
 #    },
 #    'loggers': {
-#        'root': {
-#            'level': 'ERROR',
-#            'handlers': ['sentry'],
-#        },
 #        'raven': {
 #            'level': 'WARNING',
 #            'handlers': ['console'],
@@ -134,6 +136,10 @@ FCM_SERVER_KEY = 'your server key'
 #            'handlers': ['sentry'],
 #        }
 #    },
+#    'root': {
+#        'level': 'ERROR',
+#        'handlers': ['sentry'],
+#     },
 #}
 
 #HUEY = {


### PR DESCRIPTION
The root node of the logger gets configured _aside_ the loggers, as the
print command could have made me suspicious...