### PR TITLE
Send notifications only to verified e-mail addresses

### DIFF
--- a/foodsaving/conversations/tasks.py
+++ b/foodsaving/conversations/tasks.py
@@ -22,6 +22,7 @@ def notify_participants(message):
     participants_to_notify = ConversationParticipant.objects.filter(
         conversation=message.conversation,
         email_notifications=True,
+        user__mail_verified=True,
     ).exclude(
         user=message.author
     ).exclude(


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/issues/921

This solves the backend bit and can be merged immediately.