### PR TITLE
Don't notify about non-active store pickups

### DIFF
--- a/foodsaving/pickups/tasks.py
+++ b/foodsaving/pickups/tasks.py
@@ -8,12 +8,14 @@ from foodsaving.groups.models import Group, GroupMembership, GroupNotificationTy
 from foodsaving.pickups import stats
 from foodsaving.pickups.emails import prepare_pickup_notification_email
 from foodsaving.pickups.models import PickupDate
+from foodsaving.stores.models import StoreStatus
 from foodsaving.users.models import User
 from foodsaving.utils import stats_utils
 
 
 def fetch_user_pickups(group, user, start_date, end_date):
     return PickupDate.objects.filter(
+        store__status=StoreStatus.ACTIVE.value,
         store__group=group,
         date__gte=start_date,
         date__lt=end_date,
@@ -54,6 +56,7 @@ def fetch_pickup_notification_data_for_group(group):
     pickups = PickupDate.objects.annotate(
         num_collectors=Count('collectors'),
     ).filter(
+        store__status=StoreStatus.ACTIVE.value,
         store__group=group,
     ).order_by('date')
 

--- a/foodsaving/stores/models.py
+++ b/foodsaving/stores/models.py
@@ -1,15 +1,24 @@
+from enum import Enum
+
 from django.conf import settings
 from django.db import models
 
 from foodsaving.base.base_models import BaseModel, LocationModel
 
 
+class StoreStatus(Enum):
+    CREATED = 'created'
+    NEGOTIATING = 'negotiating'
+    ACTIVE = 'active'
+    DECLINED = 'declined'
+    ARCHIVED = 'archived'
+
+
 class Store(BaseModel, LocationModel):
     class Meta:
         unique_together = ('group', 'name')
 
-    DEFAULT_STATUS = 'created'
-    STATUSES = (DEFAULT_STATUS, 'negotiating', 'active', 'declined', 'archived')
+    DEFAULT_STATUS = StoreStatus.CREATED.value
 
     group = models.ForeignKey('groups.Group', on_delete=models.CASCADE, related_name='store')
     name = models.CharField(max_length=settings.NAME_MAX_LENGTH)

--- a/foodsaving/stores/serializers.py
+++ b/foodsaving/stores/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from foodsaving.history.models import History, HistoryTypus
 from foodsaving.history.utils import get_changed_data
-from foodsaving.stores.models import Store as StoreModel
+from foodsaving.stores.models import Store as StoreModel, StoreStatus
 
 
 class StoreSerializer(serializers.ModelSerializer):
@@ -25,7 +25,7 @@ class StoreSerializer(serializers.ModelSerializer):
         }
 
     status = serializers.ChoiceField(
-        choices=StoreModel.STATUSES,
+        choices=[status.value for status in StoreStatus],
         default=StoreModel.DEFAULT_STATUS
     )
 


### PR DESCRIPTION
The first pickup notifications would notify about pickups in non-active stores, this changes it so it matches the frontend logic to hide pickups unless the store is `active`.