### PR TITLE
Add feedback to weekly summaries

### DIFF
--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -20,19 +20,23 @@ def prepare_group_summary_data(group, from_date, to_date):
         groupmembership__created_at__lt=to_date,
     ).all()
 
-    pickups_done_count = PickupDate.objects \
-        .annotate(num_collectors=Count('collectors')) \
-        .filter(store__group=group,
-                date__gte=from_date,
-                date__lt=to_date,
-                num_collectors__gt=0).count()
+    pickups_done_count = PickupDate.objects.annotate(
+        num_collectors=Count('collectors')
+    ).filter(
+        store__group=group,
+        date__gte=from_date,
+        date__lt=to_date,
+        num_collectors__gt=0,
+    ).count()
 
-    pickups_missed_count = PickupDate.objects \
-        .annotate(num_collectors=Count('collectors')) \
-        .filter(store__group=group,
-                date__gte=from_date,
-                date__lt=to_date,
-                num_collectors=0).count()
+    pickups_missed_count = PickupDate.objects.annotate(
+        num_collectors=Count('collectors')
+    ).filter(
+        store__group=group,
+        date__gte=from_date,
+        date__lt=to_date,
+        num_collectors=0,
+    ).count()
 
     feedbacks = Feedback.objects.filter(
         created_at__gte=from_date,

--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -10,7 +10,7 @@ from django.utils.timezone import get_current_timezone
 from config import settings
 from foodsaving.conversations.models import ConversationMessage
 from foodsaving.groups.models import Group, GroupNotificationType, GroupMembership
-from foodsaving.pickups.models import PickupDate
+from foodsaving.pickups.models import PickupDate, Feedback
 from foodsaving.utils.email_utils import prepare_email
 
 
@@ -34,6 +34,12 @@ def prepare_group_summary_data(group, from_date, to_date):
                 date__lt=to_date,
                 num_collectors=0).count()
 
+    feedbacks = Feedback.objects.filter(
+        created_at__gte=from_date,
+        created_at__lt=to_date,
+        about__store__group=group,
+    )
+
     messages = ConversationMessage.objects.filter(
         conversation__target_type=ContentType.objects.get_for_model(Group),
         conversation__target_id=group.id,
@@ -54,6 +60,7 @@ def prepare_group_summary_data(group, from_date, to_date):
         'new_users': new_users,
         'pickups_done_count': pickups_done_count,
         'pickups_missed_count': pickups_missed_count,
+        'feedbacks': feedbacks,
         'messages': messages,
         'settings_url': settings_url,
     }

--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -70,9 +70,8 @@ def prepare_group_summary_data(group, from_date, to_date):
     }
 
 
-def prepare_group_summary_emails(group, from_date, to_date):
+def prepare_group_summary_emails(group, context):
     """Prepares one email per language"""
-    context = prepare_group_summary_data(group, from_date, to_date)
 
     members = group.members.filter(
         groupmembership__in=GroupMembership.objects.with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)

--- a/foodsaving/groups/stats.py
+++ b/foodsaving/groups/stats.py
@@ -34,13 +34,13 @@ def group_activity(group):
     }])
 
 
-def group_summary_email(group, recipient_count):
+def group_summary_email(group, **extra_fields):
     write_points([{
         'measurement': 'karrot.email.group_summary',
         'tags': {
             'group': str(group.id)
         },
-        'fields': {'value': 1, 'recipient_count': recipient_count},
+        'fields': {'value': 1, **extra_fields},
     }])
 
 

--- a/foodsaving/groups/templates/group_summary.mjml
+++ b/foodsaving/groups/templates/group_summary.mjml
@@ -37,6 +37,12 @@
                                 </li>
                             {% endif %}
 
+                            {% if feedbacks|length > 0 %}
+                                <li>{% trans feedbacks_count=feedbacks|length %}{{ feedbacks_count }} pickup feedbacks were given{% endtrans %}</li>
+                            {% else %}
+                                <li>{% trans %}no feedback was given{% endtrans %}</li>
+                            {% endif %}
+
                             {% if messages|length > 0 %}
                                 <li>{% trans sent_messages_count=messages|length %}{{ sent_messages_count }} messages were sent{% endtrans %}</li>
                             {% else %}
@@ -44,9 +50,28 @@
                             {% endif %}
                         </ul>
 
+                        {% if feedbacks|length > 0 %}
+                            <div class="divider"></div>
+                            <br>
+                            <h3>{% trans %}Pickup feedback{% endtrans %}</h3>
+                            {% for feedback in feedbacks %}
+                                <p class="feedback">
+                                    <em>{{ feedback.comment }}</em>
+                                    <br>
+                                    <span style="font-size: 14px;">
+                                        {{ feedback.weight }}kg
+                                        from
+                                        <a href="{{ store_url(feedback.about.store) }}">
+                                            {{ feedback.about.store.name }}
+                                        </a>
+                                    </span>
+                                </p>
+                            {% endfor %}
+                        {% endif %}
+
                         {% if messages|length > 0 %}
                             <div class="divider"></div>
-                            <p>{% trans %}Here's what was said last week{% endtrans %}:</p>
+                            <h3>{% trans %}Here's what was said last week{% endtrans %}</h3>
                             {% for message in messages %}
                                 <div class="message">
                                     <span class="message-author">{{ message.author.display_name }}</span><br>

--- a/foodsaving/groups/templates/group_summary.mjml
+++ b/foodsaving/groups/templates/group_summary.mjml
@@ -59,11 +59,13 @@
                                     <em>{{ feedback.comment }}</em>
                                     <br>
                                     <span style="font-size: 14px;">
-                                        {{ feedback.weight }}kg
-                                        from
-                                        <a href="{{ store_url(feedback.about.store) }}">
-                                            {{ feedback.about.store.name }}
-                                        </a>
+                                        {% trans weight=feedback.weight, store_url=store_url(feedback.about.store), store_name=feedback.about.store.name %}
+                                            {{ weight }}kg
+                                            from
+                                            <a href="{{ store_url }}">
+                                                {{ store_name }}
+                                            </a>
+                                        {% endtrans %}
                                     </span>
                                 </p>
                             {% endfor %}

--- a/foodsaving/groups/tests/test_emails.py
+++ b/foodsaving/groups/tests/test_emails.py
@@ -32,8 +32,9 @@ class TestGroupSummaryEmails(APITestCase):
         for i in list(range(n)):
             self.group.add_member(VerifiedUserFactory(language='en'))
 
-        from_date, to_date = foodsaving.groups.emails.calculate_group_summary_dates(self.group)
-        emails = foodsaving.groups.emails.prepare_group_summary_emails(self.group, from_date, to_date)
+        from_date, to_date = group_emails.calculate_group_summary_dates(self.group)
+        context = group_emails.prepare_group_summary_data(self.group, from_date, to_date)
+        emails = group_emails.prepare_group_summary_emails(self.group, context)
         self.assertEqual(len(emails), 1)
 
         expected_members = self.group.members.filter(
@@ -61,7 +62,8 @@ class TestGroupSummaryEmails(APITestCase):
             self.group.add_member(VerifiedUserFactory(language='fr'))
 
         from_date, to_date = group_emails.calculate_group_summary_dates(self.group)
-        emails = group_emails.prepare_group_summary_emails(self.group, from_date, to_date)
+        context = group_emails.prepare_group_summary_data(self.group, from_date, to_date)
+        emails = group_emails.prepare_group_summary_emails(self.group, context)
         self.assertEqual(len(emails), 3)
 
         to = []

--- a/foodsaving/groups/tests/test_tasks.py
+++ b/foodsaving/groups/tests/test_tasks.py
@@ -1,14 +1,19 @@
 from datetime import timedelta
+from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
 from django.core import mail
 from django.test import TestCase
 from django.utils import timezone
+from freezegun import freeze_time
 
 from config import settings
 from foodsaving.groups.factories import GroupFactory
 from foodsaving.groups.models import GroupMembership
-from foodsaving.groups.tasks import process_inactive_users
-from foodsaving.users.factories import UserFactory
+from foodsaving.groups.tasks import process_inactive_users, send_summary_emails
+from foodsaving.pickups.factories import PickupDateFactory, FeedbackFactory
+from foodsaving.stores.factories import StoreFactory
+from foodsaving.users.factories import UserFactory, VerifiedUserFactory
 
 
 class TestProcessInactiveUsers(TestCase):
@@ -41,3 +46,60 @@ class TestProcessInactiveUsers(TestCase):
         process_inactive_users()
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.inactive_user.email])
+
+
+class TestSummaryEmailTask(TestCase):
+    def setUp(self):
+        self.group = GroupFactory()
+
+    @patch('foodsaving.groups.stats.write_points')
+    def test_collects_stats(self, write_points):
+        a_few_days_ago = timezone.now() - relativedelta(days=4)
+        store = StoreFactory(group=self.group)
+
+        message_count = 10
+        pickups_missed_count = 5
+        feedback_count = 4
+        new_user_count = 3
+        pickups_done_count = 8
+
+        new_users = [VerifiedUserFactory() for _ in range(new_user_count)]
+        user = new_users[0]
+
+        with freeze_time(a_few_days_ago, tick=True):
+            [self.group.add_member(u) for u in new_users]
+
+            # a couple of messages
+            [self.group.conversation.messages.create(author=user, content='hello') for _ in range(message_count)]
+
+            # missed pickups
+            [PickupDateFactory(store=store) for _ in range(pickups_missed_count)]
+
+            # fullfilled pickups
+            pickups = [
+                PickupDateFactory(store=store, max_collectors=1, collectors=[user])
+                for _ in range(pickups_done_count)
+            ]
+
+            # pickup feedback
+            [FeedbackFactory(about=pickup, given_by=user) for pickup in pickups[:feedback_count]]
+
+        write_points.reset_mock()
+
+        send_summary_emails()
+
+        write_points.assert_called_with([{
+            'measurement': 'karrot.email.group_summary',
+            'tags': {
+                'group': str(self.group.id)
+            },
+            'fields': {
+                'value': 1,
+                'new_user_count': new_user_count,
+                'email_recipient_count': new_user_count,
+                'feedback_count': feedback_count,
+                'pickups_missed_count': pickups_missed_count,
+                'message_count': message_count,
+                'pickups_done_count': pickups_done_count,
+            },
+        }])

--- a/foodsaving/management/commands/create_sample_data.py
+++ b/foodsaving/management/commands/create_sample_data.py
@@ -189,6 +189,26 @@ class Command(BaseCommand):
             print('left pickup: ', pickup)
             return data
 
+        def make_feedback(pickup, given_by):
+            data = c.post('/api/feedback/', {
+                'comment': faker.text(),
+                'weight': 100.0,
+                'about': pickup,
+                'given_by': given_by,
+            }).data
+            print('created feedback: ', data)
+            return data
+
+        def create_done_pickup(store, user_id):
+            pickup = PickupDate.objects.create(
+                date=faker.date_time_between(start_date='-9d', end_date='-1d', tzinfo=pytz.utc),
+                store_id=store,
+                max_collectors=10,
+            )
+            pickup.collectors.add(User.objects.get(pk=user_id))
+            print('created pickup: ', pickup)
+            return pickup
+
         ######################
         # Sample data
         ######################
@@ -208,6 +228,9 @@ class Command(BaseCommand):
                 make_series(store['id'])
                 pickup = make_pickup(store['id'])
                 join_pickup(pickup['id'])
+                done_pickup = create_done_pickup(store['id'], user['id'])
+                join_pickup(done_pickup.id)
+                make_feedback(done_pickup.id, user['id'])
 
         # group members
         min_members = (10, 4, 1)[i]

--- a/foodsaving/template_previews/views.py
+++ b/foodsaving/template_previews/views.py
@@ -8,10 +8,10 @@ from django.template.loader import render_to_string
 from django.template.utils import get_app_template_dirs
 from django.utils import timezone
 
-import foodsaving.groups.emails
 from config import settings
 from foodsaving.conversations.models import ConversationMessage
-from foodsaving.groups.emails import prepare_user_inactive_in_group_email
+from foodsaving.groups.emails import prepare_user_inactive_in_group_email, prepare_group_summary_emails, \
+    prepare_group_summary_data
 from foodsaving.groups.models import Group
 from foodsaving.invitations.models import Invitation
 from foodsaving.pickups.emails import prepare_pickup_notification_email
@@ -68,7 +68,8 @@ class Handlers:
         from_date = timezone.now() - relativedelta(days=7)
         to_date = from_date + relativedelta(days=7)
 
-        summary_emails = foodsaving.groups.emails.prepare_group_summary_emails(group, from_date, to_date)
+        context = prepare_group_summary_data(group, from_date, to_date)
+        summary_emails = prepare_group_summary_emails(group, context)
         if len(summary_emails) is 0:
             raise Exception(
                 'No emails were generated, you need at least one verified user in your db, and some activity data...')

--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -32,12 +32,18 @@ def store_url(store):
         store_id=store.id,
     )
 
+def user_url(user):
+    return '{hostname}/#/user/{user_id}/'.format(
+        hostname=settings.HOSTNAME,
+        user_id=user.id,
+    )
 
 def jinja2_environment(**options):
     env = Environment(**options)
     env.filters['date'] = date_filter
     env.filters['time'] = time_filter
     env.globals['store_url'] = store_url
+    env.globals['user_url'] = user_url
     return env
 
 

--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -32,11 +32,13 @@ def store_url(store):
         store_id=store.id,
     )
 
+
 def user_url(user):
     return '{hostname}/#/user/{user_id}/'.format(
         hostname=settings.HOSTNAME,
         user_id=user.id,
     )
+
 
 def jinja2_environment(**options):
     env = Environment(**options)


### PR DESCRIPTION
I noticed there is some nice feedback in some of the groups I am in, so should show it in the summary email to for motivating factors.

TODO:
- [x] add stats collection to make sure the emails don't get too enormous (messages + feedback particularly)

Looks a bit like this:

![summarywithfeedback](https://user-images.githubusercontent.com/31616/37230656-954115be-23e8-11e8-8b74-1527fb84fcc7.png)
