### PR TITLE
Handle timezone in jinja2 filters

### DIFF
--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string, get_template
 from django.utils import translation
+from django.utils.timezone import get_current_timezone
 from django.utils.translation import to_locale, get_language
 from furl import furl
 from jinja2 import Environment
@@ -18,11 +19,20 @@ from foodsaving.webhooks.api import make_local_part
 
 
 def date_filter(value):
-    return format_date(value, format='full', locale=to_locale(get_language()))
+    return format_date(
+        value.astimezone(get_current_timezone()),
+        format='full',
+        locale=to_locale(get_language()),
+    )
 
 
 def time_filter(value):
-    return format_time(value, format='short', locale=to_locale(get_language()))
+    return format_time(
+        value,
+        format='short',
+        locale=to_locale(get_language()),
+        tzinfo=get_current_timezone(),
+    )
 
 
 def store_url(store):

--- a/foodsaving/utils/tests/test_email_utils.py
+++ b/foodsaving/utils/tests/test_email_utils.py
@@ -1,4 +1,7 @@
-from rest_framework.test import APITestCase
+from unittest import TestCase
+
+import pytz
+from django.utils import timezone
 
 from config import settings
 from foodsaving.groups.factories import GroupFactory
@@ -6,9 +9,10 @@ from foodsaving.invitations.models import Invitation
 from foodsaving.userauth.models import VerificationCode
 from foodsaving.users.factories import UserFactory
 from foodsaving.utils import email_utils
+from foodsaving.utils.email_utils import time_filter, date_filter
 
 
-class TestEmailUtils(APITestCase):
+class TestEmailUtils(TestCase):
     def setUp(self):
         self.group = GroupFactory()
         self.user = UserFactory()
@@ -59,3 +63,35 @@ class TestEmailUtils(APITestCase):
         self.assertEqual(email.to[0], self.user.unverified_email)
         self.assertIn(settings.HOSTNAME, email.body)
         self.assertIn(verification_code.code, email.body)
+
+
+class TestJinjaFilters(TestCase):
+
+    def test_time_filter_uses_timezone(self):
+        datetime = timezone.now().replace(
+            tzinfo=pytz.utc,
+            hour=5,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        with timezone.override(pytz.timezone('Europe/Berlin')):
+            val = time_filter(datetime)
+            self.assertEqual(val, '6:00 AM')
+
+    def test_date_filter_uses_timezone(self):
+        # 11pm on Sunday UTC
+        datetime = timezone.now().replace(
+            tzinfo=pytz.utc,
+            year=2018,
+            month=3,
+            day=11,
+            hour=23,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        with timezone.override(pytz.timezone('Europe/Berlin')):
+            # ... is Monday in Berlin
+            val = date_filter(datetime)
+            self.assertIn('Monday', val)

--- a/foodsaving/utils/tests/test_email_utils.py
+++ b/foodsaving/utils/tests/test_email_utils.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 import pytz
 from django.utils import timezone
+from django.test import TestCase
 
 from config import settings
 from foodsaving.groups.factories import GroupFactory


### PR DESCRIPTION
The babel datetime library is not connected with django so it does not know to get the current timezone from there.

Should fix it :)