### PR TITLE
Don't send notifications to inactive users

### DIFF
--- a/foodsaving/conversations/tasks.py
+++ b/foodsaving/conversations/tasks.py
@@ -1,33 +1,30 @@
 from anymail.exceptions import AnymailAPIError
-from dateutil.relativedelta import relativedelta
-from django.utils.timezone import now
 from huey.contrib.djhuey import db_task
-
-from django.conf import settings
 from raven.contrib.django.raven_compat.models import client as sentry_client
 
 from foodsaving.conversations.models import ConversationParticipant
+from foodsaving.groups.models import Group, GroupMembership
+from foodsaving.users.models import User
 from foodsaving.utils import email_utils
-from foodsaving.webhooks.models import EmailEvent
 
 
 @db_task()
 def notify_participants(message):
-    # exclude emails that had bounces or similar events recently
-    ignored_addresses = EmailEvent.objects.filter(
-        created_at__gte=now() - relativedelta(months=6),
-        event__in=settings.EMAIL_EVENTS_AVOID
-    ).values('address')
-
     participants_to_notify = ConversationParticipant.objects.filter(
         conversation=message.conversation,
         email_notifications=True,
-        user__mail_verified=True,
     ).exclude(
         user=message.author
     ).exclude(
-        user__email__in=ignored_addresses
+        user__in=User.objects.unverified_or_ignored(),
     )
+
+    if isinstance(message.conversation.target, Group):
+        # if it's a group conversation, only send to users who are active in that group
+        participants_to_notify = participants_to_notify.filter(
+            user__groupmembership__in=GroupMembership.objects.active(),
+            user__groupmembership__group=message.conversation.target,
+        )
 
     for participant in participants_to_notify:
         try:

--- a/foodsaving/conversations/tests/test_tasks.py
+++ b/foodsaving/conversations/tests/test_tasks.py
@@ -1,0 +1,25 @@
+from django.core import mail
+from django.test import TestCase
+from django.utils import timezone
+
+from foodsaving.conversations.tasks import notify_participants
+from foodsaving.groups.factories import GroupFactory
+from foodsaving.users.factories import VerifiedUserFactory, UserFactory
+
+
+class TestConversationNotificationTask(TestCase):
+
+    def setUp(self):
+        self.user = VerifiedUserFactory()
+        self.unverified_user = UserFactory()
+        self.inactive_user = VerifiedUserFactory()
+        self.author = VerifiedUserFactory()
+        self.group = GroupFactory(members=[self.author, self.user, self.inactive_user, self.unverified_user])
+        self.group.groupmembership_set.filter(user=self.inactive_user).update(inactive_at=timezone.now())
+        self.message = self.group.conversation.messages.create(author=self.author, content='foo')
+        mail.outbox = []
+
+    def test_only_notifies_active_group_members(self):
+        notify_participants(self.message)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.user.email])

--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -74,7 +74,9 @@ def prepare_group_summary_emails(group, context):
     """Prepares one email per language"""
 
     members = group.members.filter(
-        groupmembership__in=GroupMembership.objects.with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+        groupmembership__in=GroupMembership.objects \
+            .active() \
+            .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
     ).exclude(
         groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
     )

--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -74,9 +74,9 @@ def prepare_group_summary_emails(group, context):
     """Prepares one email per language"""
 
     members = group.members.filter(
-        groupmembership__in=GroupMembership.objects \
-            .active() \
-            .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+        groupmembership__in=GroupMembership.objects.active().with_notification_type(
+            GroupNotificationType.WEEKLY_SUMMARY
+        )
     ).exclude(
         groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
     )

--- a/foodsaving/groups/models.py
+++ b/foodsaving/groups/models.py
@@ -3,7 +3,7 @@ from enum import Enum
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import TextField, DateTimeField, Manager
+from django.db.models import TextField, DateTimeField, QuerySet
 from django.utils import timezone
 from timezone_field import TimeZoneField
 
@@ -42,13 +42,14 @@ class Group(BaseModel, LocationModel, ConversationMixin):
         return 'Group {}'.format(self.name)
 
     def add_member(self, user, history_payload=None):
-        GroupMembership.objects.create(group=self, user=user)
+        membership = GroupMembership.objects.create(group=self, user=user)
         History.objects.create(
             typus=HistoryTypus.GROUP_JOIN,
             group=self,
             users=[user, ],
             payload=history_payload
         )
+        return membership
 
     def remove_member(self, user):
         History.objects.create(
@@ -97,14 +98,17 @@ def get_default_notification_types():
     ]
 
 
-class GroupMembershipManager(Manager):
+class GroupMembershipQuerySet(QuerySet):
 
     def with_notification_type(self, type):
         return self.filter(notification_types__contains=[type])
 
+    def active(self):
+        return self.filter(inactive_at__isnull=True)
+
 
 class GroupMembership(BaseModel):
-    objects = GroupMembershipManager()
+    objects = GroupMembershipQuerySet.as_manager()
 
     group = models.ForeignKey(Group, on_delete=models.CASCADE)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/foodsaving/groups/tests/test_emails.py
+++ b/foodsaving/groups/tests/test_emails.py
@@ -1,3 +1,5 @@
+from random import randint
+
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -23,9 +25,18 @@ class TestGroupSummaryEmails(APITestCase):
         m.notification_types = []
         m.save()
 
-        unverified_users = [UserFactory(language='en') for i in list(range(3))]
+        # it should ignore unverified and inactive users so adding a random number
+        # of them here should not change anything
+
+        unverified_users = [UserFactory(language='en') for _ in list(range(randint(2, 5)))]
         for user in unverified_users:
             self.group.add_member(user)
+
+        inactive_users = [VerifiedUserFactory(language='en') for _ in list(range(randint(2, 5)))]
+        for user in inactive_users:
+            membership = self.group.add_member(user)
+            membership.inactive_at = timezone.now()
+            membership.save()
 
     def test_creates_one_email_for_one_language(self):
         n = 5
@@ -38,7 +49,9 @@ class TestGroupSummaryEmails(APITestCase):
         self.assertEqual(len(emails), 1)
 
         expected_members = self.group.members.filter(
-            groupmembership__in=GroupMembership.objects.with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+            groupmembership__in=GroupMembership.objects \
+                .active() \
+                .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
         ).exclude(
             groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
         )
@@ -71,7 +84,9 @@ class TestGroupSummaryEmails(APITestCase):
             to.extend(email.to)
 
         expected_members = self.group.members.filter(
-            groupmembership__in=GroupMembership.objects.with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+            groupmembership__in=GroupMembership.objects \
+                .active() \
+                .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
         ).exclude(
             groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
         )

--- a/foodsaving/groups/tests/test_emails.py
+++ b/foodsaving/groups/tests/test_emails.py
@@ -49,9 +49,9 @@ class TestGroupSummaryEmails(APITestCase):
         self.assertEqual(len(emails), 1)
 
         expected_members = self.group.members.filter(
-            groupmembership__in=GroupMembership.objects \
-                .active() \
-                .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+            groupmembership__in=GroupMembership.objects.active().with_notification_type(
+                GroupNotificationType.WEEKLY_SUMMARY
+            )
         ).exclude(
             groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
         )
@@ -84,9 +84,9 @@ class TestGroupSummaryEmails(APITestCase):
             to.extend(email.to)
 
         expected_members = self.group.members.filter(
-            groupmembership__in=GroupMembership.objects \
-                .active() \
-                .with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
+            groupmembership__in=GroupMembership.objects.active().with_notification_type(
+                GroupNotificationType.WEEKLY_SUMMARY
+            )
         ).exclude(
             groupmembership__user__in=get_user_model().objects.unverified_or_ignored()
         )

--- a/foodsaving/pickups/tasks.py
+++ b/foodsaving/pickups/tasks.py
@@ -69,9 +69,9 @@ def fetch_pickup_notification_data_for_group(group):
     base_tomorrow_not_full = pickups.filter(**tomorrow, **not_full)
 
     users = group.members.filter(
-        groupmembership__in=GroupMembership.objects. \
-            active(). \
-            with_notification_type(GroupNotificationType.DAILY_PICKUP_NOTIFICATION),
+        groupmembership__in=GroupMembership.objects.active().with_notification_type(
+            GroupNotificationType.DAILY_PICKUP_NOTIFICATION
+        ),
     ).exclude(
         groupmembership__user__in=User.objects.unverified_or_ignored(),
     )

--- a/foodsaving/pickups/tasks.py
+++ b/foodsaving/pickups/tasks.py
@@ -69,8 +69,9 @@ def fetch_pickup_notification_data_for_group(group):
     base_tomorrow_not_full = pickups.filter(**tomorrow, **not_full)
 
     users = group.members.filter(
-        groupmembership__in=GroupMembership.objects.with_notification_type(
-            GroupNotificationType.DAILY_PICKUP_NOTIFICATION),
+        groupmembership__in=GroupMembership.objects. \
+            active(). \
+            with_notification_type(GroupNotificationType.DAILY_PICKUP_NOTIFICATION),
     ).exclude(
         groupmembership__user__in=User.objects.unverified_or_ignored(),
     )

--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -3,7 +3,6 @@ from email.utils import formataddr
 import html2text
 from anymail.message import AnymailMessage
 from babel.dates import format_date, format_time
-from django.contrib.contenttypes.models import ContentType
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string, get_template
 from django.utils import translation

--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -78,10 +78,10 @@ def prepare_changemail_success_email(user):
 
 
 def prepare_conversation_message_notification(user, message):
-    group = message.conversation.target
-    target_type = message.conversation.target_type
-    if group is None or target_type != ContentType.objects.get_for_model(Group):
+    if not isinstance(message.conversation.target, Group):
         raise Exception('Cannot send message notification if conversation does not belong to a group')
+
+    group = message.conversation.target
 
     reply_to_name = group.name
     conversation_url = '{hostname}/#/group/{group_id}/wall'.format(


### PR DESCRIPTION
Inactive users should not be notified about 3 kinds of things:
- group wall messages
- daily pickup notifications
- weekly group summary emails

They should still receive other emails.