### PR TITLE
Playground group backend

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -29,7 +29,7 @@ from foodsaving.template_previews import views as template_preview_views
 router = routers.DefaultRouter()
 
 router.register('groups', GroupViewSet)
-router.register('groups-info', GroupInfoViewSet)
+router.register('groups-info', GroupInfoViewSet, base_name='groupinfo')
 router.register('agreements', AgreementViewSet)
 
 # User endpoints
@@ -70,7 +70,7 @@ urlpatterns = [
     path('api/webhooks/incoming_email/', IncomingEmailView.as_view()),
     path('api/webhooks/email_event/', EmailEventView.as_view()),
     path('api/auth/', AuthView.as_view()),
-    path('api/', include(router.urls)),
+    path('api/', include((router.urls))),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('admin/docs/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),

--- a/foodsaving/conversations/models.py
+++ b/foodsaving/conversations/models.py
@@ -38,9 +38,9 @@ class Conversation(BaseModel, UpdatedAtMixin):
     target_id = models.PositiveIntegerField(null=True)
     target = GenericForeignKey('target_type', 'target_id')
 
-    def join(self, user):
+    def join(self, user, **kwargs):
         if not self.conversationparticipant_set.filter(user=user).exists():
-            ConversationParticipant.objects.create(user=user, conversation=self)
+            ConversationParticipant.objects.create(user=user, conversation=self, **kwargs)
 
     def leave(self, user):
         self.conversationparticipant_set.filter(user=user).delete()

--- a/foodsaving/groups/factories.py
+++ b/foodsaving/groups/factories.py
@@ -1,6 +1,6 @@
 from factory import DjangoModelFactory, post_generation, LazyAttribute
 
-from foodsaving.groups.models import Group as GroupModel, GroupMembership
+from foodsaving.groups.models import Group as GroupModel, GroupMembership, GroupStatus
 from foodsaving.utils.tests.fake import faker
 
 
@@ -20,3 +20,11 @@ class GroupFactory(DjangoModelFactory):
     name = LazyAttribute(lambda x: faker.name())
     description = LazyAttribute(lambda x: faker.sentence(nb_words=40))
     public_description = LazyAttribute(lambda x: faker.sentence(nb_words=20))
+
+
+class PlaygroundGroupFactory(GroupFactory):
+    status = GroupStatus.PLAYGROUND.value
+
+
+class InactiveGroupFactory(GroupFactory):
+    status = GroupStatus.INACTIVE.value

--- a/foodsaving/groups/models.py
+++ b/foodsaving/groups/models.py
@@ -66,6 +66,9 @@ class Group(BaseModel, LocationModel, ConversationMixin):
         return not user.is_anonymous and GroupMembership.objects.filter(group=self, user=user,
                                                                         roles__contains=[role_name]).exists()
 
+    def is_playground(self):
+        return self.status == GroupStatus.PLAYGROUND.value
+
     def accept_invite(self, user, invited_by, invited_at):
         self.add_member(user, history_payload={
             'invited_by': invited_by.id,

--- a/foodsaving/groups/receivers.py
+++ b/foodsaving/groups/receivers.py
@@ -3,7 +3,7 @@ from django.dispatch import receiver
 
 from foodsaving.conversations.models import Conversation, ConversationParticipant
 from foodsaving.groups import roles, stats
-from foodsaving.groups.models import Group, GroupMembership, GroupStatus
+from foodsaving.groups.models import Group, GroupMembership
 
 
 @receiver(post_save, sender=Group)

--- a/foodsaving/groups/templates/group_summary.mjml
+++ b/foodsaving/groups/templates/group_summary.mjml
@@ -59,13 +59,9 @@
                                     <em>{{ feedback.comment }}</em>
                                     <br>
                                     <span style="font-size: 14px;">
-                                        {% trans weight=feedback.weight, store_url=store_url(feedback.about.store), store_name=feedback.about.store.name %}
-                                            {{ weight }}kg
-                                            from
-                                            <a href="{{ store_url }}">
-                                                {{ store_name }}
-                                            </a>
-                                        {% endtrans %}
+                                    {% trans weight=feedback.weight, store_url=store_url(feedback.about.store), store_name=feedback.about.store.name -%}
+                                        {{ weight }} kg from <a href="{{ store_url }}">{{ store_name }}</a>
+                                    {% endtrans %}
                                     </span>
                                 </p>
                             {% endfor %}

--- a/foodsaving/groups/templates/group_summary.subject.jinja2
+++ b/foodsaving/groups/templates/group_summary.subject.jinja2
@@ -1,1 +1,1 @@
-[{{ site_name }}] {{ group.name }} updates for the week of {{ from_date | date }}
+[{{ site_name }}] {% trans group_name=group.name, day=from_date|date %}{{ group_name }} updates for the week of {{ day }}{% endtrans %}

--- a/foodsaving/groups/templates/playground_public_description.nopreview.jinja2
+++ b/foodsaving/groups/templates/playground_public_description.nopreview.jinja2
@@ -1,0 +1,5 @@
+{% trans %}Welcome to **karrot**!
+
+Come in, click around and do whatever you feel like! :carrot: No need to worry, nothing can be broken here! :)
+
+All email notifications are disabled by default.{% endtrans %}

--- a/foodsaving/groups/tests/test_api.py
+++ b/foodsaving/groups/tests/test_api.py
@@ -3,10 +3,11 @@ import json
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from foodsaving.groups import roles
-from foodsaving.groups.factories import GroupFactory
+from foodsaving.groups.factories import GroupFactory, PlaygroundGroupFactory
 from foodsaving.groups.models import Group as GroupModel, GroupMembership, Agreement, UserAgreement, \
     GroupNotificationType, get_default_notification_types
 from foodsaving.pickups.factories import PickupDateFactory
@@ -210,6 +211,20 @@ class TestGroupsAPI(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
+
+class TestPlaygroundGroupAPI(APITestCase):
+    def setUp(self):
+        self.member = UserFactory()
+        self.group = PlaygroundGroupFactory(members=[self.member], password='')
+
+    def test_change_password_has_no_effect(self):
+        self.client.force_login(user=self.member)
+        url = reverse('group-detail', kwargs={'pk': self.group.id})
+        print(url)
+        response = self.client.patch(url, data={'password': 'secret'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.group.refresh_from_db()
+        self.assertEqual(self.group.password, '')
 
 class TestGroupMembershipRolesAPI(APITestCase):
     def setUp(self):

--- a/foodsaving/groups/tests/test_api.py
+++ b/foodsaving/groups/tests/test_api.py
@@ -226,6 +226,7 @@ class TestPlaygroundGroupAPI(APITestCase):
         self.group.refresh_from_db()
         self.assertEqual(self.group.password, '')
 
+
 class TestGroupMembershipRolesAPI(APITestCase):
     def setUp(self):
         self.admin = UserFactory()  # has membership management rights

--- a/foodsaving/groups/tests/test_model.py
+++ b/foodsaving/groups/tests/test_model.py
@@ -2,9 +2,10 @@ from django.db import DataError
 from django.db import IntegrityError
 from django.test import TestCase
 
+from foodsaving.conversations.models import Conversation, ConversationParticipant
 from foodsaving.groups import roles
-from foodsaving.groups.factories import GroupFactory
-from foodsaving.groups.models import Group, GroupMembership
+from foodsaving.groups.factories import GroupFactory, PlaygroundGroupFactory
+from foodsaving.groups.models import Group, GroupMembership, get_default_notification_types
 from foodsaving.users.factories import UserFactory
 
 
@@ -21,5 +22,23 @@ class TestGroupModel(TestCase):
     def test_roles_initialized(self):
         user = UserFactory()
         group = GroupFactory(members=[user])
-        membership = GroupMembership.objects.filter(user=user, group=group).first()
+        membership = GroupMembership.objects.get(user=user, group=group)
         self.assertIn(roles.GROUP_MEMBERSHIP_MANAGER, membership.roles)
+
+    def test_notifications_on_by_default(self):
+        user = UserFactory()
+        group = GroupFactory(members=[user])
+        membership = GroupMembership.objects.get(user=user, group=group)
+        self.assertEqual(get_default_notification_types(), membership.notification_types)
+        conversation = Conversation.objects.get_for_target(group)
+        conversation_participant = ConversationParticipant.objects.get(conversation=conversation, user=user)
+        self.assertTrue(conversation_participant.email_notifications)
+
+    def test_no_notifications_by_default_in_playground(self):
+        user = UserFactory()
+        group = PlaygroundGroupFactory(members=[user])
+        membership = GroupMembership.objects.get(user=user, group=group)
+        self.assertEqual([], membership.notification_types)
+        conversation = Conversation.objects.get_for_target(group)
+        conversation_participant = ConversationParticipant.objects.get(conversation=conversation, user=user)
+        self.assertFalse(conversation_participant.email_notifications)

--- a/foodsaving/locale/en/LC_MESSAGES/django.po
+++ b/foodsaving/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-09 16:09+0000\n"
+"POT-Creation-Date: 2018-03-15 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,23 +58,27 @@ msgstr ""
 msgid "You do not have permission to update memberships."
 msgstr ""
 
-#: foodsaving/groups/serializers.py:22
+#: foodsaving/groups/serializers.py:23
 msgid "Unknown timezone"
 msgstr ""
 
-#: foodsaving/groups/serializers.py:88 foodsaving/groups/serializers.py:158
+#: foodsaving/groups/serializers.py:31
+msgid "Playground"
+msgstr ""
+
+#: foodsaving/groups/serializers.py:100 foodsaving/groups/serializers.py:175
 msgid "You cannot manage agreements"
 msgstr ""
 
-#: foodsaving/groups/serializers.py:90
+#: foodsaving/groups/serializers.py:102
 msgid "Agreement is not for this group"
 msgstr ""
 
-#: foodsaving/groups/serializers.py:156
+#: foodsaving/groups/serializers.py:173
 msgid "You are not in this group"
 msgstr ""
 
-#: foodsaving/groups/serializers.py:223
+#: foodsaving/groups/serializers.py:240
 msgid "Group password is wrong"
 msgstr ""
 
@@ -115,27 +119,62 @@ msgstr ""
 
 #: foodsaving/groups/templates/group_summary.html.jinja2:137
 #, python-format
-msgid "%(sent_messages_count)s messages were sent"
+msgid "%(feedbacks_count)s pickup feedbacks were given"
 msgstr ""
 
 #: foodsaving/groups/templates/group_summary.html.jinja2:139
-msgid "no messages were sent"
+msgid "no feedback was given"
+msgstr ""
+
+#: foodsaving/groups/templates/group_summary.html.jinja2:143
+#, python-format
+msgid "%(sent_messages_count)s messages were sent"
 msgstr ""
 
 #: foodsaving/groups/templates/group_summary.html.jinja2:145
+msgid "no messages were sent"
+msgstr ""
+
+#: foodsaving/groups/templates/group_summary.html.jinja2:152
+msgid "Pickup feedback"
+msgstr ""
+
+#: foodsaving/groups/templates/group_summary.html.jinja2:158
+#, python-format
+msgid ""
+"%(weight)s kg from <a href=\"%(store_url)s\">%(store_name)s</a>\n"
+"                                    "
+msgstr ""
+
+#: foodsaving/groups/templates/group_summary.html.jinja2:167
 msgid "Here's what was said last week"
 msgstr ""
 
-#: foodsaving/groups/templates/group_summary.html.jinja2:153
+#: foodsaving/groups/templates/group_summary.html.jinja2:175
 msgid ""
 "You are receiving this because you are subscribed to <strong>Weekly summary</"
 "strong> emails for this group."
 msgstr ""
 
-#: foodsaving/groups/templates/group_summary.html.jinja2:154
+#: foodsaving/groups/templates/group_summary.html.jinja2:176
 #: foodsaving/pickups/templates/pickup_notification.html.jinja2:186
 #, python-format
 msgid "<a href=\"%(settings_url)s\">Change your settings</a>."
+msgstr ""
+
+#: foodsaving/groups/templates/group_summary.subject.jinja2:1
+#, python-format
+msgid "%(group_name)s updates for the week of %(day)s"
+msgstr ""
+
+#: foodsaving/groups/templates/playground_public_description.nopreview.jinja2:1
+msgid ""
+"Welcome to **karrot**!\n"
+"\n"
+"Come in, click around and do whatever you feel like! :carrot: No need to "
+"worry, nothing can be broken here! :)\n"
+"\n"
+"All email notifications are disabled by default."
 msgstr ""
 
 #: foodsaving/groups/templates/user_inactive_in_group.html.jinja2:109

--- a/foodsaving/template_previews/views.py
+++ b/foodsaving/template_previews/views.py
@@ -29,8 +29,10 @@ def random_user():
 
 
 def random_group():
-    return Group.objects.order_by('?').first()
+    return shuffle_groups().first()
 
+def shuffle_groups():
+    return Group.objects.order_by('?')
 
 def random_message():
     return ConversationMessage.objects.order_by('?').first()
@@ -63,17 +65,19 @@ class Handlers:
         return email_utils.prepare_emailinvitation_email(invitation)
 
     def group_summary(self):
-        group = random_group()
-
         from_date = timezone.now() - relativedelta(days=7)
         to_date = from_date + relativedelta(days=7)
 
-        context = prepare_group_summary_data(group, from_date, to_date)
-        summary_emails = prepare_group_summary_emails(group, context)
-        if len(summary_emails) is 0:
-            raise Exception(
-                'No emails were generated, you need at least one verified user in your db, and some activity data...')
-        return summary_emails[0]
+        for group in shuffle_groups():
+            context = prepare_group_summary_data(group, from_date, to_date)
+            summary_emails = prepare_group_summary_emails(group, context)
+            if len(summary_emails) is 0:
+                continue
+
+            return summary_emails[0]
+
+        raise Exception(
+            'No emails were generated, you need at least one verified user in your db, and some activity data...')
 
     def mailverification(self):
         return email_utils.prepare_mailverification_email(
@@ -140,7 +144,7 @@ def list_templates(request):
         for directory, dirnames, filenames in os.walk(directory):
             relative_dir = directory[len(foodsaving_basedir) + 1:]
             for filename in filenames:
-                if re.match(r'.*\.jinja2$', filename):
+                if re.match(r'.*\.jinja2$', filename) and not re.match(r'.*\.nopreview\.jinja2$', filename):
                     path = os.path.join(relative_dir, filename)
 
                     # strip out anything past the first dot for the name

--- a/foodsaving/template_previews/views.py
+++ b/foodsaving/template_previews/views.py
@@ -31,8 +31,10 @@ def random_user():
 def random_group():
     return shuffle_groups().first()
 
+
 def shuffle_groups():
     return Group.objects.order_by('?')
+
 
 def random_message():
     return ConversationMessage.objects.order_by('?').first()


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/pull/960

- disable all notifications by default (messages, pickup notifications, weekly summary)
- disable "is missing" email if user becomes inactive
- disable editing of group name and password and public_description
- translatable group name and public_description

Unrelated changes:
- make group summary email subject translatable
- make template viewer for group summary email search for groups with activity
- group summary: add space between number and unit -> `20 kg`