### PR TITLE
Rework weekly summary

### DIFF
--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -56,7 +56,7 @@ def prepare_group_summary_data(group, from_date, to_date):
         group_id=group.id,
     )
 
-    return {
+    data = {
         # minus one second so it's displayed as the full day
         'to_date': to_date - relativedelta(seconds=1),
         'from_date': from_date,
@@ -68,6 +68,11 @@ def prepare_group_summary_data(group, from_date, to_date):
         'messages': messages,
         'settings_url': settings_url,
     }
+
+    data['has_activity'] = any(data[field] > 0 for field in ['pickups_done_count', 'pickups_missed_count']) or \
+        any(len(data[field]) > 0 for field in ['feedbacks', 'messages', 'new_users'])
+
+    return data
 
 
 def prepare_group_summary_emails(group, context):

--- a/foodsaving/groups/templates/group_summary.mjml
+++ b/foodsaving/groups/templates/group_summary.mjml
@@ -30,9 +30,9 @@
 
                             {% if new_users|length > 0 %}
                                 <li>
-                                    {% trans new_user_count=new_users|length %}{{ new_user_count }} people joined the group{% endtrans %}
+                                    {% trans new_user_count=new_users|length %}{{ new_user_count }} people joined the group{% endtrans %}:
                                     {% for user in new_users %}
-                                        <a href="{{ hostname }}/#/user/{{ user.id }}">{{ user.display_name }}</a>{% if not loop.last %}, {% else %}.{% endif %}
+                                        <a href="{{ hostname }}/#/user/{{ user.id }}">{{ user.display_name }}</a>{% if not loop.last %}, {% endif %}
                                     {% endfor %}
                                 </li>
                             {% endif %}
@@ -56,6 +56,7 @@
                             <h3>{% trans %}Pickup feedback{% endtrans %}</h3>
                             {% for feedback in feedbacks %}
                                 <p class="feedback">
+                                    <span class="message-author">{{ feedback.given_by.display_name }}</span>
                                     <em>{{ feedback.comment }}</em>
                                     <br>
                                     <span style="font-size: 14px;">

--- a/foodsaving/groups/tests/test_tasks.py
+++ b/foodsaving/groups/tests/test_tasks.py
@@ -69,56 +69,88 @@ class TestProcessInactiveUsersNonActiveGroup(TestCase):
 
 class TestSummaryEmailTask(TestCase):
     def setUp(self):
-        self.group = GroupFactory()
+        self.message_count = 10
+        self.pickups_missed_count = 5
+        self.feedback_count = 4
+        self.new_user_count = 3
+        self.pickups_done_count = 8
 
-    @patch('foodsaving.groups.stats.write_points')
-    def test_collects_stats(self, write_points):
-        a_few_days_ago = timezone.now() - relativedelta(days=4)
-        store = StoreFactory(group=self.group)
-
-        message_count = 10
-        pickups_missed_count = 5
-        feedback_count = 4
-        new_user_count = 3
-        pickups_done_count = 8
-
-        new_users = [VerifiedUserFactory() for _ in range(new_user_count)]
+    def make_activity_in_group(self, group):
+        store = StoreFactory(group=group)
+        new_users = [VerifiedUserFactory() for _ in range(self.new_user_count)]
         user = new_users[0]
 
+        a_few_days_ago = timezone.now() - relativedelta(days=4)
         with freeze_time(a_few_days_ago, tick=True):
-            [self.group.add_member(u) for u in new_users]
+            [group.add_member(u) for u in new_users]
 
             # a couple of messages
-            [self.group.conversation.messages.create(author=user, content='hello') for _ in range(message_count)]
+            [group.conversation.messages.create(author=user, content='hello') for _ in range(self.message_count)]
 
             # missed pickups
-            [PickupDateFactory(store=store) for _ in range(pickups_missed_count)]
+            [PickupDateFactory(store=store) for _ in range(self.pickups_missed_count)]
 
             # fullfilled pickups
             pickups = [
                 PickupDateFactory(store=store, max_collectors=1, collectors=[user])
-                for _ in range(pickups_done_count)
+                for _ in range(self.pickups_done_count)
             ]
 
             # pickup feedback
-            [FeedbackFactory(about=pickup, given_by=user) for pickup in pickups[:feedback_count]]
+            [FeedbackFactory(about=pickup, given_by=user) for pickup in pickups[:self.feedback_count]]
+
+    @patch('foodsaving.groups.stats.write_points')
+    def test_collects_stats(self, write_points):
+        group = GroupFactory()
+        self.make_activity_in_group(group)
 
         write_points.reset_mock()
+        mail.outbox = []
 
         send_summary_emails()
 
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox[0].to), self.new_user_count)
         write_points.assert_called_with([{
             'measurement': 'karrot.email.group_summary',
             'tags': {
-                'group': str(self.group.id)
+                'group': str(group.id)
             },
             'fields': {
                 'value': 1,
-                'new_user_count': new_user_count,
-                'email_recipient_count': new_user_count,
-                'feedback_count': feedback_count,
-                'pickups_missed_count': pickups_missed_count,
-                'message_count': message_count,
-                'pickups_done_count': pickups_done_count,
+                'new_user_count': self.new_user_count,
+                'email_recipient_count': self.new_user_count,
+                'feedback_count': self.feedback_count,
+                'pickups_missed_count': self.pickups_missed_count,
+                'message_count': self.message_count,
+                'pickups_done_count': self.pickups_done_count,
+                'has_activity': True,
+            },
+        }])
+
+    @patch('foodsaving.groups.stats.write_points')
+    def test_no_summary_email_if_no_activity_in_group(self, write_points):
+        group = GroupFactory(members=[VerifiedUserFactory()])
+
+        write_points.reset_mock()
+        mail.outbox = []
+
+        send_summary_emails()
+
+        self.assertEqual(len(mail.outbox), 0)
+        write_points.assert_called_with([{
+            'measurement': 'karrot.email.group_summary',
+            'tags': {
+                'group': str(group.id)
+            },
+            'fields': {
+                'value': 1,
+                'new_user_count': 0,
+                'email_recipient_count': 0,
+                'feedback_count': 0,
+                'pickups_missed_count': 0,
+                'message_count': 0,
+                'pickups_done_count': 0,
+                'has_activity': False,
             },
         }])

--- a/foodsaving/utils/tests/test_email_utils.py
+++ b/foodsaving/utils/tests/test_email_utils.py
@@ -67,16 +67,19 @@ class TestEmailUtils(TestCase):
 class TestJinjaFilters(TestCase):
 
     def test_time_filter_uses_timezone(self):
+        hour = 5
         datetime = timezone.now().replace(
             tzinfo=pytz.utc,
-            hour=5,
+            hour=hour,
             minute=0,
             second=0,
             microsecond=0,
         )
-        with timezone.override(pytz.timezone('Europe/Berlin')):
+        tz = pytz.timezone('Europe/Berlin')
+        offset_hours = int(tz.utcoffset(datetime.utcnow()).seconds / 3600)
+        with timezone.override(tz):
             val = time_filter(datetime)
-            self.assertEqual(val, '6:00 AM')
+            self.assertEqual(val, '{}:00 AM'.format(hour + offset_hours))
 
     def test_date_filter_uses_timezone(self):
         # 11pm on Sunday UTC


### PR DESCRIPTION
- Don't send empty summary emails
- Add name to feedback
- Add colon before member list

In my opinion, it would make sense to show a timestamp next to messages and the pickup time next to feedback. What do you think about it?