### PR TITLE
Add pickup conversations

### DIFF
--- a/foodsaving/conversations/api.py
+++ b/foodsaving/conversations/api.py
@@ -167,7 +167,7 @@ class RetrieveConversationMixin(object):
 
     def retrieve_conversation(self, request, *args, **kwargs):
         target = self.get_object()
-        conversation = Conversation.objects.get_for_target(target)
+        conversation = Conversation.objects.get_or_create_for_target(target)
         serializer = ConversationSerializer(conversation, data={}, context={'request': request})
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)

--- a/foodsaving/conversations/api.py
+++ b/foodsaving/conversations/api.py
@@ -167,6 +167,7 @@ class RetrieveConversationMixin(object):
 
     def retrieve_conversation(self, request, *args, **kwargs):
         target = self.get_object()
-        conversation = Conversation.objects.get_or_create_for_target(target)
-        serializer = ConversationSerializer(conversation, context={'request': request})
+        conversation = Conversation.objects.get_for_target(target)
+        serializer = ConversationSerializer(conversation, data={}, context={'request': request})
+        serializer.is_valid(raise_exception=True)
         return Response(serializer.data)

--- a/foodsaving/conversations/serializers.py
+++ b/foodsaving/conversations/serializers.py
@@ -26,6 +26,13 @@ class ConversationSerializer(serializers.ModelSerializer):
     updated_at = serializers.SerializerMethodField()
     email_notifications = serializers.SerializerMethodField()
 
+    def validate(self, data):
+        """Check the user is a participant"""
+        conversation = self.instance
+        if self.context['request'].user not in conversation.participants.all():
+            raise PermissionDenied(_('You are not in this conversation'))
+        return data
+
     def get_seen_up_to(self, conversation):
         user = self.context['request'].user
         participant = conversation.conversationparticipant_set.get(user=user)

--- a/foodsaving/pickups/api.py
+++ b/foodsaving/pickups/api.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
+from foodsaving.conversations.api import RetrieveConversationMixin
 from foodsaving.history.models import History, HistoryTypus
 from foodsaving.pickups.filters import (
     PickupDatesFilter, PickupDateSeriesFilter, FeedbackFilter
@@ -107,7 +108,8 @@ class PickupDateViewSet(
     PartialUpdateModelMixin,
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
-    GenericViewSet
+    GenericViewSet,
+    RetrieveConversationMixin
 ):
     """
     Pickup Dates
@@ -162,3 +164,8 @@ class PickupDateViewSet(
     )
     def remove(self, request, pk=None):
         return self.partial_update(request)
+
+    @detail_route()
+    def conversation(self, request, pk=None):
+        """Get conversation ID of this pickup"""
+        return self.retrieve_conversation(request, pk)

--- a/foodsaving/pickups/models.py
+++ b/foodsaving/pickups/models.py
@@ -11,6 +11,7 @@ from django.dispatch import Signal
 from django.utils import timezone
 
 from foodsaving.base.base_models import BaseModel
+from foodsaving.conversations.models import ConversationMixin
 from foodsaving.history.models import History, HistoryTypus
 from foodsaving.pickups import stats
 
@@ -158,7 +159,7 @@ class PickupDateManager(models.Manager):
             & ~Q(feedback__given_by=user)
 
 
-class PickupDate(BaseModel):
+class PickupDate(BaseModel, ConversationMixin):
     objects = PickupDateManager()
 
     class Meta:

--- a/foodsaving/pickups/receivers.py
+++ b/foodsaving/pickups/receivers.py
@@ -1,7 +1,8 @@
-from django.db.models.signals import pre_delete, post_save
+from django.db.models.signals import pre_delete, post_save, m2m_changed, post_init
 from django.dispatch import receiver
 from django.utils import timezone
 
+from foodsaving.conversations.models import Conversation
 from foodsaving.groups.models import GroupMembership
 from foodsaving.pickups import stats
 from foodsaving.pickups.models import PickupDate, Feedback
@@ -23,3 +24,32 @@ def feedback_created(sender, instance, created, **kwargs):
     if not created:
         return
     stats.feedback_given(instance)
+
+
+@receiver(post_init, sender=PickupDate)
+@receiver(post_save, sender=PickupDate)
+def pickup_created(**kwargs):
+    """Ensure every pickup has a conversation with the collectors in it."""
+    pickup = kwargs.get('instance')
+    if pickup.id is not None:
+        conversation = Conversation.objects.get_or_create_for_target(pickup)
+        conversation.sync_users(pickup.collectors.all())
+
+
+@receiver(pre_delete, sender=PickupDate)
+def pickup_deleted(**kwargs):
+    """Delete the conversation when the pickup is deleted."""
+    pickup = kwargs.get('instance')
+    conversation = Conversation.objects.get_for_target(pickup)
+    if conversation:
+        conversation.delete()
+
+
+@receiver(m2m_changed, sender=PickupDate.collectors.through)
+def sync_pickup_collectors_conversation(sender, instance, **kwargs):
+    """Update conversation participants when collectors are added or removed."""
+    action = kwargs.get('action')
+    if action and (action == 'post_add' or action == 'post_remove'):
+        pickup = instance
+        conversation = Conversation.objects.get_or_create_for_target(pickup)
+        conversation.sync_users(pickup.collectors.all())

--- a/foodsaving/subscriptions/tests/test_receivers.py
+++ b/foodsaving/subscriptions/tests/test_receivers.py
@@ -269,12 +269,19 @@ class PickupDateReceiverTests(ChannelTestCase):
         self.assertEqual(response['topic'], 'pickups:pickupdate')
         self.assertEqual(response['payload']['collector_ids'], [self.member.id])
 
+        response = self.client.receive(json=True)
+        self.assertEqual(response['topic'], 'conversations:conversation')
+        self.assertEqual(response['payload']['participants'], [self.member.id])
+
         # leave
         self.pickup.collectors.remove(self.member)
 
         response = self.client.receive(json=True)
         self.assertEqual(response['topic'], 'pickups:pickupdate')
         self.assertEqual(response['payload']['collector_ids'], [])
+
+        response = self.client.receive(json=True)
+        self.assertEqual(response['topic'], 'conversations:leave')
 
         self.assertIsNone(self.client.receive(json=True))
 


### PR DESCRIPTION
https://github.com/yunity/karrot-frontend/issues/677

Added pickup conversations to the backend. Basically just copied the implementation for the group conversations.

So, one new endpoint: `GET /api/pickup-dates/{id}/conversation/` to get the conversation for a pickup. Then you would use the message endpoints as used by the group wall for the rest.

I think we discussed before that we found this API style a bit odd in the frontend, as we kind of wanted to just have the conversation id included in the parent resource I think (i.e. a field in the group or pickup). So, perhaps I could rejig them both to try that style if you think it worth it.