### PR TITLE
Auto mark groups inactive #972

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -223,6 +223,9 @@ ACCOUNT_DELETE_TIME_LIMIT_MINUTES = 180
 # For marking users inactive
 NUMBER_OF_DAYS_UNTIL_INACTIVE_IN_GROUP = 30
 
+# For marking groups inactive
+NUMBER_OF_DAYS_GROUP_INACTIVE = 14
+
 # Default dummy settings, please override in local_settings.py
 DEFAULT_FROM_EMAIL = "testing@example.com"
 SPARKPOST_RELAY_DOMAIN = 'replies.karrot.localhost'

--- a/foodsaving/groups/tasks.py
+++ b/foodsaving/groups/tasks.py
@@ -100,3 +100,11 @@ def send_summary_emails():
         'recipient_count': recipient_count,
         'email_count': email_count,
     })
+
+
+@db_periodic_task(crontab(hour=3, minute=3))  # 3 am every day
+def mark_inactive_groups():
+    for group in Group.objects.all():
+        if not group.has_recent_activity():
+            group.status = GroupStatus.INACTIVE.value
+            group.save()

--- a/foodsaving/groups/tests/test_tasks.py
+++ b/foodsaving/groups/tests/test_tasks.py
@@ -163,8 +163,8 @@ class TestMarkInactiveGroupsTask(TestCase):
         self.group_no_recent_activity = GroupFactory()
         self.group_with_recent_activity = GroupFactory()
         self.user = UserFactory()
-        self.date_old = timezone.now() - timedelta(days=settings.NUMBER_OF_DAYS_GROUP_INACTIVE+3)
-        self.date_new = timezone.now() - timedelta(days=settings.NUMBER_OF_DAYS_GROUP_INACTIVE-3)
+        self.date_old = timezone.now() - timedelta(days=settings.NUMBER_OF_DAYS_GROUP_INACTIVE + 3)
+        self.date_new = timezone.now() - timedelta(days=settings.NUMBER_OF_DAYS_GROUP_INACTIVE - 3)
 
     def test_mark_inactive_group_trigger_wall_messages(self):
         conversation_old = Conversation.objects.get_or_create_for_target(self.group_no_recent_activity)


### PR DESCRIPTION
Implements yunity/karrot-frontend#972
I haven't implemented yet reactivation of groups. I see 2 options: add activation to the endpoint handlers for every event or to add it to overridden save method of Conversation, History and Feedback models. How would You suggest is better?