### PR TITLE
Disable creation of pickups if store is inactive

### DIFF
--- a/foodsaving/pickups/serializers.py
+++ b/foodsaving/pickups/serializers.py
@@ -35,6 +35,8 @@ class PickupDateSerializer(serializers.ModelSerializer):
     def validate_store(self, store):
         if not self.context['request'].user.groups.filter(store=store).exists():
             raise serializers.ValidationError(_('You are not member of the store\'s group.'))
+        if not store.is_active():
+            raise serializers.ValidationError(_('Store is not active'))
         return store
 
     def create(self, validated_data):
@@ -175,6 +177,8 @@ class PickupDateSeriesSerializer(serializers.ModelSerializer):
     def validate_store(self, store):
         if not store.group.is_member(self.context['request'].user):
             raise serializers.ValidationError(_('You are not member of the store\'s group.'))
+        if not store.is_active():
+            raise serializers.ValidationError(_('Store is not active'))
         return store
 
     def validate_start_date(self, date):

--- a/foodsaving/pickups/tests/test_pickupdates_api.py
+++ b/foodsaving/pickups/tests/test_pickupdates_api.py
@@ -7,6 +7,7 @@ from foodsaving.groups.factories import GroupFactory
 from foodsaving.groups.models import GroupMembership, GroupStatus
 from foodsaving.pickups.factories import PickupDateFactory
 from foodsaving.stores.factories import StoreFactory
+from foodsaving.stores.models import StoreStatus
 from foodsaving.tests.utils import ExtractPaginationMixin
 from foodsaving.users.factories import UserFactory
 
@@ -66,6 +67,13 @@ class TestPickupDatesAPI(APITestCase, ExtractPaginationMixin):
         self.assertEqual(self.group.status, GroupStatus.ACTIVE.value)
 
     def test_create_past_pickup_date_fails(self):
+        self.client.force_login(user=self.member)
+        response = self.client.post(self.url, self.past_pickup_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+
+    def test_create_pickup_date_inactive_store_fails(self):
+        self.store.status = StoreStatus.ARCHIVED.value
+        self.store.save()
         self.client.force_login(user=self.member)
         response = self.client.post(self.url, self.past_pickup_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)


### PR DESCRIPTION
Don't create/modify pickups if store is not active - yunity/karrot-frontend#1026