### PR TITLE
Prevent create_all_pickup_dates from generating for inactive stores

### DIFF
--- a/foodsaving/pickups/models.py
+++ b/foodsaving/pickups/models.py
@@ -14,6 +14,7 @@ from foodsaving.base.base_models import BaseModel
 from foodsaving.conversations.models import ConversationMixin
 from foodsaving.history.models import History, HistoryTypus
 from foodsaving.pickups import stats
+from foodsaving.stores.models import StoreStatus
 
 pickup_done = Signal()
 
@@ -21,7 +22,7 @@ pickup_done = Signal()
 class PickupDateSeriesManager(models.Manager):
     @transaction.atomic
     def create_all_pickup_dates(self):
-        for series in self.all():
+        for series in self.filter(store__status=StoreStatus.ACTIVE.value):
             series.update_pickup_dates()
 
 

--- a/foodsaving/stores/serializers.py
+++ b/foodsaving/stores/serializers.py
@@ -45,7 +45,8 @@ class StoreSerializer(serializers.ModelSerializer):
         changed_data = get_changed_data(store, validated_data)
         store = super().update(store, validated_data)
 
-        if 'weeks_in_advance' in changed_data:
+        if 'weeks_in_advance' in changed_data or \
+                ('status' in changed_data and store.status == StoreStatus.ACTIVE.value):
             with transaction.atomic():
                 for series in store.series.all():
                     series.update_pickup_dates()

--- a/foodsaving/stores/tests/test_stores_api.py
+++ b/foodsaving/stores/tests/test_stores_api.py
@@ -10,6 +10,7 @@ from foodsaving.groups.factories import GroupFactory
 from foodsaving.groups.models import GroupStatus
 from foodsaving.pickups.factories import PickupDateSeriesFactory
 from foodsaving.stores.factories import StoreFactory
+from foodsaving.stores.models import StoreStatus
 from foodsaving.tests.utils import ExtractPaginationMixin
 from foodsaving.users.factories import UserFactory
 from foodsaving.utils.tests.fake import faker
@@ -211,3 +212,12 @@ class TestStoreChangesPickupDateSeriesAPI(APITestCase, ExtractPaginationMixin):
         self.client.force_login(user=self.member)
         response = self.client.patch(self.store_url, {'weeks_in_advance': 0})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+
+    def test_set_store_active_status_updates_pickup_dates(self):
+        self.store.status = StoreStatus.ARCHIVED.value
+        self.store.save()
+        self.store.pickup_dates.all().delete()
+        self.client.force_login(user=self.member)
+        response = self.client.patch(self.store_url, {'status': StoreStatus.ACTIVE.value}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(self.store.pickup_dates.count(), 0)


### PR DESCRIPTION
Instead of yunity/karrot-backend#549 for yunity/karrot-frontend#1026