### PR TITLE
Add API to retrieve failed email deliveries

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -22,7 +22,7 @@ from foodsaving.subscriptions.api import PushSubscriptionViewSet
 from foodsaving.template_previews import views as template_preview_views
 from foodsaving.userauth.api import AuthUserView, AuthView, LogoutView, \
     RequestResetPasswordView, ChangePasswordView, VerifyMailView, ResendMailVerificationCodeView, ResetPasswordView, \
-    ChangeMailView, RequestDeleteUserView
+    ChangeMailView, RequestDeleteUserView, FailedEmailDeliveryView
 from foodsaving.users.api import UserViewSet
 from foodsaving.webhooks.api import IncomingEmailView, EmailEventView
 
@@ -64,6 +64,7 @@ urlpatterns = [
     path('api/auth/logout/', LogoutView.as_view()),
     path('api/auth/user/', AuthUserView.as_view()),
     path('api/auth/user/request_delete/', RequestDeleteUserView.as_view()),
+    path('api/auth/user/failed_email_deliveries/', FailedEmailDeliveryView.as_view()),
     path('api/auth/email/', ChangeMailView.as_view()),
     path('api/auth/email/verify/', VerifyMailView.as_view()),
     path('api/auth/email/resend_verification_code/', ResendMailVerificationCodeView.as_view()),

--- a/foodsaving/userauth/api.py
+++ b/foodsaving/userauth/api.py
@@ -3,6 +3,7 @@ from django.contrib.auth import logout, update_session_auth_hash
 from django.utils.translation import ugettext as _
 from django.middleware.csrf import get_token as generate_csrf_token_for_frontend
 from rest_framework import status, generics, views
+from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 
@@ -10,7 +11,7 @@ from foodsaving.userauth.models import VerificationCode
 from foodsaving.userauth.permissions import MailIsNotVerified
 from foodsaving.userauth.serializers import AuthLoginSerializer, AuthUserSerializer, \
     ChangePasswordSerializer, RequestResetPasswordSerializer, ChangeMailSerializer, \
-    VerificationCodeSerializer, ResetPasswordSerializer
+    VerificationCodeSerializer, ResetPasswordSerializer, FailedEmailDeliverySerialier
 
 
 class LogoutView(views.APIView):
@@ -186,3 +187,29 @@ class ChangeMailView(generics.GenericAPIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(status=status.HTTP_204_NO_CONTENT, data={})
+
+
+class FailedEmailDeliveryPagination(CursorPagination):
+    # TODO: create an index on 'created_at' for increased speed
+    page_size = 10
+    ordering = '-created_at'
+
+
+class FailedEmailDeliveryView(generics.GenericAPIView):
+    permission_classes = (IsAuthenticated,)
+    serializer_class = FailedEmailDeliverySerialier
+    pagination_class = FailedEmailDeliveryPagination
+
+    def get(self, request):
+        """
+        Get email bounces etc
+        """
+        queryset = self.filter_queryset(request.user.failed_email_deliveries())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/foodsaving/userauth/api.py
+++ b/foodsaving/userauth/api.py
@@ -11,7 +11,7 @@ from foodsaving.userauth.models import VerificationCode
 from foodsaving.userauth.permissions import MailIsNotVerified
 from foodsaving.userauth.serializers import AuthLoginSerializer, AuthUserSerializer, \
     ChangePasswordSerializer, RequestResetPasswordSerializer, ChangeMailSerializer, \
-    VerificationCodeSerializer, ResetPasswordSerializer, FailedEmailDeliverySerialier
+    VerificationCodeSerializer, ResetPasswordSerializer, FailedEmailDeliverySerializer
 
 
 class LogoutView(views.APIView):
@@ -197,7 +197,7 @@ class FailedEmailDeliveryPagination(CursorPagination):
 
 class FailedEmailDeliveryView(generics.GenericAPIView):
     permission_classes = (IsAuthenticated,)
-    serializer_class = FailedEmailDeliverySerialier
+    serializer_class = FailedEmailDeliverySerializer
     pagination_class = FailedEmailDeliveryPagination
 
     def get(self, request):

--- a/foodsaving/userauth/serializers.py
+++ b/foodsaving/userauth/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from versatileimagefield.serializers import VersatileImageFieldSerializer
 
 from foodsaving.userauth.models import VerificationCode
+from foodsaving.webhooks.models import EmailEvent
 
 
 class AuthLoginSerializer(serializers.Serializer):
@@ -194,3 +195,18 @@ class RequestResetPasswordSerializer(serializers.Serializer):
         except AnymailAPIError:
             raise serializers.ValidationError(_('We could not send you an e-mail.'))
         return user
+
+
+class FailedEmailDeliverySerialier(serializers.ModelSerializer):
+    class Meta:
+        model = EmailEvent
+        fields = ['created_at', 'address', 'event', 'reason', 'subject']
+
+    reason = serializers.SerializerMethodField()
+    subject = serializers.SerializerMethodField()
+
+    def get_reason(self, event):
+        return event.payload.get('reason')
+
+    def get_subject(self, event):
+        return event.payload.get('subject')

--- a/foodsaving/userauth/serializers.py
+++ b/foodsaving/userauth/serializers.py
@@ -197,7 +197,7 @@ class RequestResetPasswordSerializer(serializers.Serializer):
         return user
 
 
-class FailedEmailDeliverySerialier(serializers.ModelSerializer):
+class FailedEmailDeliverySerializer(serializers.ModelSerializer):
     class Meta:
         model = EmailEvent
         fields = ['created_at', 'address', 'event', 'reason', 'subject']

--- a/foodsaving/users/models.py
+++ b/foodsaving/users/models.py
@@ -217,3 +217,6 @@ class User(AbstractBaseUser, BaseModel, LocationModel):
     def has_module_perms(self, app_label):
         # temporarily only allow access for admins
         return self.is_superuser
+
+    def failed_email_deliveries(self):
+        return EmailEvent.objects.for_user(self)

--- a/foodsaving/webhooks/models.py
+++ b/foodsaving/webhooks/models.py
@@ -17,7 +17,6 @@ class EmailEventManager(BaseUserManager):
         )
 
     def ignored_addresses(self):
-        # return []
         return self.ignored().values('address').annotate(count=Count('id')).filter(count__gte=5).values('address')
 
     def for_user(self, user):

--- a/foodsaving/webhooks/models.py
+++ b/foodsaving/webhooks/models.py
@@ -21,7 +21,7 @@ class EmailEventManager(BaseUserManager):
 
     def for_user(self, user):
         return self.ignored().filter(
-            address=user.address
+            address=user.email
         )
 
 

--- a/foodsaving/webhooks/models.py
+++ b/foodsaving/webhooks/models.py
@@ -1,7 +1,7 @@
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.postgres.fields import JSONField
-from django.db.models import CharField, TextField, BigAutoField
+from django.db.models import CharField, TextField, BigAutoField, Count
 from django.utils import timezone
 
 from config import settings
@@ -10,11 +10,20 @@ from foodsaving.base.base_models import BaseModel
 
 class EmailEventManager(BaseUserManager):
 
-    def ignored_addresses(self):
+    def ignored(self):
         return self.filter(
-            created_at__gte=timezone.now() - relativedelta(months=6),
+            created_at__gte=timezone.now() - relativedelta(months=3),
             event__in=settings.EMAIL_EVENTS_AVOID
-        ).values('address')
+        )
+
+    def ignored_addresses(self):
+        # return []
+        return self.ignored().values('address').annotate(count=Count('id')).filter(count__gte=5).values('address')
+
+    def for_user(self, user):
+        return self.ignored().filter(
+            address=user.address
+        )
 
 
 class EmailEvent(BaseModel):


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/issues/1050

- add /api/auth/user/failed_email_deliveries/ (paginated, defaults to 10 events)
- returns some whitelisted fields of `EmailEvent`: subject, reason, event, created_at
- relax automatic notification blacklist: needs more than 5 failed deliveries in the last 3 months to prevent sending