### PR TITLE
A few conversation loading tweaks

### DIFF
--- a/foodsaving/conversations/api.py
+++ b/foodsaving/conversations/api.py
@@ -204,7 +204,7 @@ class RetrieveConversationMixin(object):
 
     def retrieve_conversation(self, request, *args, **kwargs):
         target = self.get_object()
-        conversation = Conversation.objects.filter_for_target(target).prefetch_related('participants').first()
+        conversation = Conversation.objects.get_or_create_for_target(target)
         serializer = ConversationSerializer(conversation, data={}, context={'request': request})
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)

--- a/foodsaving/conversations/models.py
+++ b/foodsaving/conversations/models.py
@@ -37,7 +37,6 @@ class ConversationManager(models.Manager):
             raise Exception('Users need to be different')
         conv = Conversation.objects.filter(is_private=True, participants=user1)\
             .filter(participants=user2)\
-            .prefetch_related('participants')\
             .first()
         if not conv:
             conv = Conversation.objects.create(is_private=True)

--- a/foodsaving/conversations/serializers.py
+++ b/foodsaving/conversations/serializers.py
@@ -28,7 +28,7 @@ class ConversationSerializer(serializers.ModelSerializer):
     def validate(self, data):
         """Check the user is a participant"""
         conversation = self.instance
-        if self.context['request'].user not in conversation.participants.all():
+        if not self._participant(conversation):
             raise PermissionDenied(_('You are not in this conversation'))
         return data
 
@@ -59,7 +59,7 @@ class ConversationSerializer(serializers.ModelSerializer):
     def _participant(self, conversation):
         user = self.context['request'].user
         if 'participant' not in self.context:
-            self.context['participant'] = conversation.conversationparticipant_set.get(user=user)
+            self.context['participant'] = conversation.conversationparticipant_set.filter(user=user).first()
         return self.context['participant']
 
 


### PR DESCRIPTION
Fixes #557 

I had removed the get_or_create behaviour for conversations (group/pickup ones), but that was not right sentry told me.

I also refined the ConversationSerializer so the prefetch is not useful anymore (as it was only used for during an inefficient membership check).