### PR TITLE
Improve stat tags for message/reactions

### DIFF
--- a/foodsaving/conversations/stats.py
+++ b/foodsaving/conversations/stats.py
@@ -1,27 +1,36 @@
 from influxdb_metrics.loader import write_points
 
+from foodsaving.groups.models import Group
+from foodsaving.pickups.models import PickupDate
+
 
 def message_written(message):
-    tags = {}
-    c = message.conversation
-    if c.target:
-        key = c.target_type.name  # e.g. group
-        tags[key] = c.target_id
     write_points([{
         'measurement': 'karrot.events',
-        'tags': tags,
+        'tags': tags_for_conversation(message.conversation),
         'fields': {'message': 1},
     }])
 
 
 def reaction_given(reaction):
-    tags = {}
-    c = reaction.message.conversation
-    if c.target:
-        key = c.target_type.name  # e.g. group
-        tags[key] = c.target_id
     write_points([{
         'measurement': 'karrot.events',
-        'tags': tags,
+        'tags': tags_for_conversation(reaction.message.conversation),
         'fields': {'message_reaction': 1},
     }])
+
+
+def tags_for_conversation(conversation):
+    tags = {}
+    target = conversation.target
+    if isinstance(target, Group):
+        tags['group'] = target.id
+        tags['type'] = 'group'
+    elif isinstance(target, PickupDate):
+        tags['group'] = target.store.group_id
+        tags['type'] = 'pickup'
+    elif conversation.is_private:
+        tags['type'] = 'private'
+    else:
+        tags['type'] = 'unknown'
+    return tags

--- a/foodsaving/conversations/tests/test_stats.py
+++ b/foodsaving/conversations/tests/test_stats.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from foodsaving.conversations.factories import ConversationFactory
+from foodsaving.conversations.stats import tags_for_conversation
+from foodsaving.groups.factories import GroupFactory
+from foodsaving.pickups.factories import PickupDateFactory
+from foodsaving.stores.factories import StoreFactory
+
+
+class TestConversationStats(TestCase):
+
+    def test_tags_for_group_conversation(self):
+        group = GroupFactory()
+        tags = tags_for_conversation(group.conversation)
+        self.assertEqual(tags, {'type': 'group', 'group': group.id})
+
+    def test_tags_for_pickup_conversation(self):
+        group = GroupFactory()
+        store = StoreFactory(group=group)
+        pickup = PickupDateFactory(store=store)
+        tags = tags_for_conversation(pickup.conversation)
+        self.assertEqual(tags, {'type': 'pickup', 'group': group.id})
+
+    def test_tags_for_private_conversation(self):
+        conversation = ConversationFactory(is_private=True)
+        tags = tags_for_conversation(conversation)
+        self.assertEqual(tags, {'type': 'private'})
+
+    def test_tags_for_other_conversation(self):
+        conversation = ConversationFactory()
+        tags = tags_for_conversation(conversation)
+        self.assertEqual(tags, {'type': 'unknown'})


### PR DESCRIPTION
Currently we store target_type and target_id but this isn't very useful for our stats as we don't really care which pickup the message is about, but the group it is part of, and the type, this fixes that so it sends:

* Group conversation: `{ type: 'group', group: 1 }`
* Pickup conversation: `{ type: 'pickup', group: 1 }`
* Private conversation: `{ type: 'private' }`