### PR TITLE
Add new store statistics endpoint

### DIFF
--- a/foodsaving/pickups/models.py
+++ b/foodsaving/pickups/models.py
@@ -154,10 +154,13 @@ class PickupDateManager(models.Manager):
             pickup_done.send(sender=PickupDate.__class__, instance=pickup)
 
     def feedback_possible_q(self, user):
-        return Q(date__lte=timezone.now()) \
+        return Q(done_and_processed=True) \
             & Q(date__gte=timezone.now() - relativedelta(days=settings.FEEDBACK_POSSIBLE_DAYS)) \
             & Q(collectors=user) \
             & ~Q(feedback__given_by=user)
+
+    def done(self):
+        return self.annotate(Count('collectors')).filter(done_and_processed=True).exclude(collectors__count=0)
 
 
 class PickupDate(BaseModel, ConversationMixin):

--- a/foodsaving/pickups/tests/test_pickupdates_api_filter.py
+++ b/foodsaving/pickups/tests/test_pickupdates_api_filter.py
@@ -129,6 +129,8 @@ class TestFeedbackPossibleFilter(APITestCase, ExtractPaginationMixin):
             store=self.store, collectors=[self.member2, ], date=self.oneWeekAgo
         )
 
+        PickupDateModel.objects.process_finished_pickup_dates()
+
     def test_filter_feedback_possible(self):
         self.client.force_login(user=self.member)
         response = self.get_results(self.url, {'feedback_possible': True})

--- a/foodsaving/stores/api.py
+++ b/foodsaving/stores/api.py
@@ -1,9 +1,13 @@
+from django.db.models import Avg, Count, Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins
+from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from foodsaving.pickups.models import PickupDate
 from foodsaving.stores.models import Store as StoreModel
 from foodsaving.stores.serializers import StoreSerializer
 from foodsaving.utils.mixins import PartialUpdateModelMixin
@@ -31,4 +35,23 @@ class StoreViewSet(
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
-        return self.queryset.filter(group__members=self.request.user)
+        qs = self.queryset.filter(group__members=self.request.user)
+        if self.action == 'statistics':
+            return qs.annotate(
+                feedback_count=Count('pickup_dates__feedback'),
+                pickups_done=Count('pickup_dates', filter=Q(pickup_dates__in=PickupDate.objects.done()))
+            )
+        else:
+            return qs
+
+    @action(detail=True)
+    def statistics(self, request, pk=None):
+        instance = self.get_object()
+        weight = instance.pickup_dates.annotate(avg_weight=Avg('feedback__weight'))\
+            .aggregate(estimated_weight=Sum('avg_weight'))['estimated_weight']
+        data = {
+            'feedback_count': instance.feedback_count,
+            'feedback_weight': round(weight or 0),
+            'pickups_done': instance.pickups_done,
+        }
+        return Response(data)

--- a/foodsaving/stores/serializers.py
+++ b/foodsaving/stores/serializers.py
@@ -11,16 +11,25 @@ from foodsaving.stores.models import Store as StoreModel, StoreStatus
 class StoreSerializer(serializers.ModelSerializer):
     class Meta:
         model = StoreModel
-        fields = ['id', 'name', 'description', 'group',
-                  'address', 'latitude', 'longitude',
-                  'weeks_in_advance', 'status']
+        fields = [
+            'id',
+            'name',
+            'description',
+            'group',
+            'address',
+            'latitude',
+            'longitude',
+            'weeks_in_advance',
+            'status',
+        ]
+
         extra_kwargs = {
             'name': {
-                'min_length': 3
+                'min_length': 3,
             },
             'description': {
                 'trim_whitespace': False,
-                'max_length': settings.DESCRIPTION_MAX_LENGTH
+                'max_length': settings.DESCRIPTION_MAX_LENGTH,
             }
         }
 


### PR DESCRIPTION
Add endpoint `/api/stores/:id/statistics/` to deliver these numbers
- number of pickups done
- number of feedback entries given
- sum of feedback weight (if there are multiple feedback entries per pickup, calculate the average over them)

These queries can be quite expensive, so in future we should think of something to speed it up, either by response caching or precalculating the numbers and storing them in the database.