### PR TITLE
Fix html to text newline issue

### DIFF
--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -48,6 +48,7 @@ def generate_plaintext_from_html(html):
     h.ignore_tables = True
     h.inline_links = False
     h.ignore_images = True
+    h.wrap_links = False
     return h.handle(html)
 
 

--- a/foodsaving/utils/tests/test_email_utils.py
+++ b/foodsaving/utils/tests/test_email_utils.py
@@ -9,7 +9,7 @@ from foodsaving.groups.factories import GroupFactory
 from foodsaving.invitations.models import Invitation
 from foodsaving.userauth.models import VerificationCode
 from foodsaving.users.factories import UserFactory
-from foodsaving.utils.email_utils import time_filter, date_filter
+from foodsaving.utils.email_utils import time_filter, date_filter, generate_plaintext_from_html
 
 
 class TestEmailUtils(TestCase):
@@ -62,6 +62,16 @@ class TestEmailUtils(TestCase):
         self.assertEqual(email.to[0], self.user.unverified_email)
         self.assertIn(settings.HOSTNAME, html)
         self.assertIn(verification_code.code, html)
+
+
+class TestHTMLToPlainText(TestCase):
+    def test_does_not_split_links(self):
+        # token that causes html2text to make a line break if wrap_links option is not set
+        token = '4522e1fa-9827-44ec-bf76-f7fa8fb132ff'
+        url = 'http://localhost:8080/#/signup?invite={}&email=please%40join.com'.format(token)
+        html = '<a href="{}">some link</a>'.format(url)
+        text = generate_plaintext_from_html(html)
+        self.assertIn(url, text)
 
 
 class TestJinjaFilters(TestCase):

--- a/yapf.py
+++ b/yapf.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
 import subprocess
-subprocess.run([
+import sys
+args = [
     'yapf',
     '-i',
     '-r',
     '-e',
     'foodsaving/*/migrations',
     'foodsaving',
-])
+    *sys.argv[1:],
+]
+print(' '.join(args))
+subprocess.run(args)


### PR DESCRIPTION
The symptom was invite tests that seemed kind of flaky. The issue was that html2text library would sometimes add newlines inside links, it would only do it for some pattern of the url, and as we have UUIDs in there, occasionally it would trigger the issue.

Configuring html2text to never wrap links fixes the issue :)

I also snuck in a random and unrelated change to the yapf script... (in a new commit, so no squash please!)