### PR TITLE
Send websocket subprotocol as response

### DIFF
--- a/foodsaving/subscriptions/consumers.py
+++ b/foodsaving/subscriptions/consumers.py
@@ -42,12 +42,16 @@ class TokenAuthMiddleware:
 class WebsocketConsumer(JsonWebsocketConsumer):
     def connect(self):
         """The user has connected! Register their channel subscription."""
+        protocol = None
         if 'user' in self.scope:
             user = self.scope['user']
             if not user.is_anonymous:
                 ChannelSubscription.objects.create(user=user, reply_channel=self.channel_name)
 
-        self.accept()
+                if 'karrot.token' in self.scope['subprotocols']:
+                    protocol = 'karrot.token'
+
+        self.accept(protocol)
 
     def message_send(self, content, **kwargs):
         if 'text' not in content:


### PR DESCRIPTION
I found out today that websocket connections didn't work anymore in Cordova. Turns out that we need to accept the 'karrot.token' subprotocol.

This might have been caused by the recent channels2 upgrade, or by the upgrade of `reconnecting-websocket` in the frontend.