### PR TITLE
Let the CI help us with updating locales

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,6 @@ jobs:
           key: python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
       - run:
           name: install hub
-          environment:
-            LC_ALL: C.UTF-8
-            LANG: C.UTF-8
           command: |
             wget https://github.com/github/hub/releases/download/v2.5.1/hub-linux-amd64-2.5.1.tgz
             tar -xf hub-linux-amd64-2.5.1.tgz
@@ -115,10 +112,10 @@ jobs:
             rm hub-linux-amd64-2.5.1.tgz
             rm -r hub-linux-amd64-2.5.1
       - run:
+          name: set git remote to include token
+          command: git remote set-url origin https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git
+      - run:
           name: update locales and make pull request
-          environment:
-            LC_ALL: C.UTF-8
-            LANG: C.UTF-8
           command: |
             set -xe
             git config credential.helper 'cache --timeout=120'
@@ -129,8 +126,7 @@ jobs:
             rm foodsaving/locale/de/LC_MESSAGES/django.po
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
-            # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
-            hub push origin circleci-update-locales
+            git push origin circleci-update-locales
             hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,28 +139,7 @@ workflows:
   version: 2
   all-the-things:
     jobs:
-      - test
-      - deploy-dev:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - test
-      - deploy-karrot-world:
-          filters:
-            branches:
-              only:
-                - production
-          requires:
-            - test
-      - deploy-foodsharing-taiwan:
-          filters:
-            branches:
-              only:
-                - production
-          requires:
-            - test
+      - update-locales
   update-locales:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,15 +123,14 @@ jobs:
             git config credential.helper 'cache --timeout=120'
             git config user.email "ci@foodsaving.world"
             git config user.name "CircleCI"
+            git checkout circleci-update-locales || git checkout -b circleci-update-locales
             env/bin/tx pull -a --force --no-interactive
-            git diff-index --exit-code HEAD || (
-                git checkout circleci-update-locales || git checkout -b circleci-update-locales
-                git add foodsaving/locale
-                git commit -m "[CI] update locales"
-                # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
-                hub push origin
-                hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
-            )
+            git add foodsaving/locale
+            rm foodsaving/locale/de/LC_MESSAGES/django.po
+            git commit -m "[CI] update locales" || exit 0
+            # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
+            hub push origin
+            hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,17 +116,20 @@ jobs:
           command: git remote set-url origin https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git
       - run:
           name: update locales and make pull request
+          environment:
+            BRANCH: circleci-update-locales
           command: |
             set -xe
             git config credential.helper 'cache --timeout=120'
             git config user.email "ci@foodsaving.world"
             git config user.name "CircleCI"
-            git checkout circleci-update-locales || git checkout -b circleci-update-locales
+            git branch --delete --force $BRANCH || true
+            git checkout -b $BRANCH
             env/bin/tx pull -a --force --no-interactive
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
-            git push origin circleci-update-locales
-            hub pull-request -m "[CI] Update locales" || exit 0
+            git push --force origin $BRANCH
+            hub pull-request -m "[CI] Update locales" || true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,33 @@
 defaults: &defaults
-    working_directory: ~/repo
-    docker:
-      - image: karrot/python:1.7
+  working_directory: ~/repo
+  docker:
+    - image: karrot/python:1.7
+
+aliases:
+  - &restore-env-cache
+    restore_cache:
+      keys:
+        - python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        - python-cache-{{ checksum "requirements.txt" }}-
+        - python-cache-
+
+  - &save-env-cache
+    save_cache:
+      paths:
+        - env
+      key: python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+
+  - &setup-env
+    run:
+      name: set up environment
+      environment:
+        LC_ALL: C.UTF-8
+        LANG: C.UTF-8
+      command: |
+        test -d env/bin || virtualenv -p python3 env
+        env/bin/pip install --upgrade pip
+        env/bin/pip install --upgrade pip-tools
+        env/bin/pip-sync requirements*.txt
 
 version: 2
 jobs:
@@ -18,30 +44,10 @@ jobs:
       - image: redis:3.2.11
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/repo
 
-      - restore_cache:
-          keys:
-            - python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - python-cache-{{ checksum "requirements.txt" }}-
-            - python-cache-
-      - run:
-          name: set up environment
-          environment:
-            LC_ALL: C.UTF-8
-            LANG: C.UTF-8
-          command: |
-            test -d env/bin || virtualenv -p python3 env
-            env/bin/pip install --upgrade pip
-            env/bin/pip install --upgrade pip-tools
-            env/bin/pip-sync requirements*.txt
-      - save_cache:
-          paths:
-            - env
-            - ~/.cache/pip
-          key: python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-
+      - *restore-env-cache
+      - *setup-env
+      - *save-env-cache
       - run:
           name: run tests
           environment:
@@ -60,6 +66,18 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
+
+  push-locale-messages:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore-env-cache
+      - run:
+          name: push source messages to transifex
+          command: |
+            set -xe
+            env/bin/python manage.py makemessages
+            env/bin/tx push -s --no-interactive
 
   deploy-dev:
     <<: *defaults
@@ -83,26 +101,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - python-cache-{{ checksum "requirements.txt" }}-
-            - python-cache-
-      - run:
-          name: set up environment
-          environment:
-            LC_ALL: C.UTF-8
-            LANG: C.UTF-8
-          command: |
-            test -d env/bin || virtualenv -p python3 env
-            env/bin/pip install --upgrade pip
-            env/bin/pip install --upgrade pip-tools
-            env/bin/pip-sync requirements*.txt
-      - save_cache:
-          paths:
-            - env
-            - ~/.cache/pip
-          key: python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+      - *restore-env-cache
+      - *setup-env
+      - *save-env-cache
       - run:
           name: install hub
           command: |
@@ -136,6 +137,13 @@ workflows:
   all-the-things:
     jobs:
       - test
+      - push-locale-messages:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - test
       - deploy-dev:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
                 hub push origin
                 hub pull-request -F - <<END
                 [CI] Update locales
-
                 There are updated locales available and you just need to click to merge them :)
                 END
             )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,8 @@ jobs:
             wget https://github.com/github/hub/releases/download/v2.5.1/hub-linux-amd64-2.5.1.tgz
             tar -xf hub-linux-amd64-2.5.1.tgz
             ./hub-linux-amd64-2.5.1/install
+            rm hub-linux-amd64-2.5.1.tgz
+            rm -r hub-linux-amd64-2.5.1
       - run:
           name: update locales
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,11 +123,11 @@ jobs:
             git config user.name "CircleCI"
             git checkout circleci-update-locales || git checkout -b circleci-update-locales
             env/bin/tx pull -a --force --no-interactive
-            rm foodsaving/locale/de/LC_MESSAGES/django.po
+            rm foodsaving/locale/pl/LC_MESSAGES/django.po
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
             git push origin circleci-update-locales
-            hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
+            hub pull-request -m "[CI] Update locales"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,19 +127,38 @@ jobs:
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
             git push origin circleci-update-locales
-            hub pull-request -m "[CI] Update locales"
+            hub pull-request -m "[CI] Update locales" || exit 0
 
 workflows:
   version: 2
   all-the-things:
     jobs:
-      - update-locales
-  update-locales:
+      - test
+      - deploy-dev:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - test
+      - deploy-karrot-world:
+          filters:
+            branches:
+              only:
+                - production
+          requires:
+            - test
+      - deploy-foodsharing-taiwan:
+          filters:
+            branches:
+              only:
+                - production
+  update-locales-cronjob:
     triggers:
       - schedule:
           cron: "0 6 * * *"
           filters:
             branches:
-              only: try-update-locales
+              only: master
     jobs:
       - update-locales

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,8 @@ jobs:
             git config user.name "CircleCI"
             git checkout circleci-update-locales || git checkout -b circleci-update-locales
             env/bin/tx pull -a --force --no-interactive
-            git add foodsaving/locale
             rm foodsaving/locale/de/LC_MESSAGES/django.po
+            git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
             # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
             hub push origin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,62 @@ jobs:
       - checkout
       - run: ./deploy.sh foodsharing-taiwan
 
+  update-locales:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - python-cache-{{ checksum "requirements.txt" }}-
+            - python-cache-
+      - run:
+          name: set up environment
+          environment:
+            LC_ALL: C.UTF-8
+            LANG: C.UTF-8
+          command: |
+            test -d env/bin || virtualenv -p python3 env
+            env/bin/pip install --upgrade pip
+            env/bin/pip install --upgrade pip-tools
+            env/bin/pip-sync requirements*.txt
+      - save_cache:
+          paths:
+            - env
+            - ~/.cache/pip
+          key: python-cache-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+      - run:
+          name: install hub
+          environment:
+            LC_ALL: C.UTF-8
+            LANG: C.UTF-8
+          command: |
+            wget https://github.com/github/hub/releases/download/v2.5.1/hub-linux-amd64-2.5.1.tgz
+            tar -xf hub-linux-amd64-2.5.1.tgz
+            ./hub-linux-amd64-2.5.1/install
+      - run:
+          name: update locales
+          environment:
+            LC_ALL: C.UTF-8
+            LANG: C.UTF-8
+          command: |
+            git config credential.helper 'cache --timeout=120'
+            git config user.email "ci@foodsaving.world"
+            git config user.name "CircleCI"
+            env/bin/tx pull -a --force --no-interactive
+            git diff-index --exit-code HEAD || (
+                git checkout circleci-update-locales || git checkout -b circleci-update-locales
+                git add foodsaving/locale
+                git commit -m "[CI] update locales"
+                # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
+                hub push origin
+                hub pull-request -F - <<END
+                [CI] Update locales
+
+                There are updated locales available and you just need to click to merge them :)
+                END
+            )
+
 workflows:
   version: 2
   all-the-things:
@@ -105,3 +161,12 @@ workflows:
                 - production
           requires:
             - test
+  update-locales:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only: try-update-locales
+    jobs:
+      - update-locales

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,10 +130,7 @@ jobs:
                 git commit -m "[CI] update locales"
                 # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
                 hub push origin
-                hub pull-request -F - <<END
-                [CI] Update locales
-                There are updated locales available and you just need to click to merge them :)
-                END
+                hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
             )
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ jobs:
             git config user.name "CircleCI"
             git checkout circleci-update-locales || git checkout -b circleci-update-locales
             env/bin/tx pull -a --force --no-interactive
-            rm foodsaving/locale/pl/LC_MESSAGES/django.po
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
             git push origin circleci-update-locales

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,11 +115,12 @@ jobs:
             rm hub-linux-amd64-2.5.1.tgz
             rm -r hub-linux-amd64-2.5.1
       - run:
-          name: update locales
+          name: update locales and make pull request
           environment:
             LC_ALL: C.UTF-8
             LANG: C.UTF-8
           command: |
+            set -xe
             git config credential.helper 'cache --timeout=120'
             git config user.email "ci@foodsaving.world"
             git config user.name "CircleCI"
@@ -129,7 +130,7 @@ jobs:
             git add foodsaving/locale
             git commit -m "[CI] update locales" || exit 0
             # git push -q https://${GITHUB_TOKEN}@github.com/yunity/karrot-backend.git master
-            hub push origin
+            hub push origin circleci-update-locales
             hub pull-request -m "[CI] Update locales\nThere are updated locales available and you just need to click to merge them :)"
 
 workflows:

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ trim_trailing_whitespace = true
 end_of_line = lf
 charset = utf-8
 
+[*.yml, *.yaml]
+indent_size = 2
+
 [*.py]
 max_line_length = 119
 


### PR DESCRIPTION
Uses the schedule feature from CircleCI to run every morning and creates a pull request if there are new translations.
After every merge to master, push source locales to transifex.

I added two secrets to CircleCI:
- TX_TOKEN for the transifex command line client
- GITHUB_TOKEN for pushing commits to our repo and creating a pull request

The github token is derived from my account, so it has admin rights. We could create another account or some "Github app" to give less privileges to the CI.