### PR TITLE
Only mention the `--more` flag if not passed in.

### DIFF
--- a/foodsaving/management/commands/create_sample_data.py
+++ b/foodsaving/management/commands/create_sample_data.py
@@ -333,6 +333,7 @@ class Command(BaseCommand):
         leave_group(o.id)
 
         print_success('Done! You can login with any of those mail addresses and password {}'.format(password))
-        print_success('Consider using the --more argument next time for more users.')
+        if not options['more_data']:
+            print_success('Consider using the --more argument next time for more users.')
 
         teardown_environment()


### PR DESCRIPTION
Tiny one for the sample data loader.

If you passed `--more` and you still see the message recommending to
pass the option, you might start to doubt that it is doing what it is
supposed to be doing.