### PR TITLE
Messages marked as read when joining a conversation.

### DIFF
--- a/foodsaving/applications/tests/test_receivers.py
+++ b/foodsaving/applications/tests/test_receivers.py
@@ -1,0 +1,22 @@
+from foodsaving.conversations.models import ConversationParticipant
+from foodsaving.groups.factories import GroupFactory
+from foodsaving.users.factories import UserFactory
+from rest_framework.test import APITestCase
+
+
+class TestGroupApplicationReceivers(APITestCase):
+    def setUp(self):
+        self.new_member = UserFactory()
+        self.existing_member = UserFactory()
+        self.group = GroupFactory(members=[self.existing_member], application_questions='')
+
+    def test_group_add_member_marks_existing_messages_as_read(self):
+        self.group.conversation.messages.create(author=self.existing_member, content='foo')
+        second_message = self.group.conversation.messages.create(author=self.existing_member, content='bar')
+
+        self.group.add_member(self.new_member)
+
+        new_participant = ConversationParticipant.objects.get(
+            user=self.new_member, conversation=self.group.conversation
+        )
+        self.assertTrue(new_participant.seen_up_to == second_message)

--- a/foodsaving/conversations/receivers.py
+++ b/foodsaving/conversations/receivers.py
@@ -46,6 +46,21 @@ def mark_as_read(sender, instance, created, **kwargs):
     participant.save()
 
 
+@receiver(post_save, sender=ConversationParticipant)
+def mark_as_read_on_join(sender, instance, created, **kwargs):
+    """When a user joins a conversation, we mark the latest message as the last seen.
+
+    This makes joining new conversations less overwhelming for users since they are
+    not presented with a potentially large backlog of unread messages.
+    """
+
+    if not created:
+        return
+
+    instance.seen_up_to = instance.conversation.latest_message
+    instance.save()
+
+
 @receiver(post_save, sender=ConversationMessage)
 def notify_participants(sender, instance, created, **kwargs):
     message = instance

--- a/foodsaving/pickups/tests/test_pickupdatecollector_receivers.py
+++ b/foodsaving/pickups/tests/test_pickupdatecollector_receivers.py
@@ -1,0 +1,28 @@
+from foodsaving.conversations.models import ConversationParticipant
+from foodsaving.groups.factories import GroupFactory
+from foodsaving.pickups.factories import PickupDateFactory
+from foodsaving.pickups.models import PickupDateCollector
+from foodsaving.stores.factories import StoreFactory
+from foodsaving.users.factories import UserFactory
+from rest_framework.test import APITestCase
+
+
+class TestPickUpCollectorReceivers(APITestCase):
+    def setUp(self):
+        self.first_member = UserFactory()
+        self.second_member = UserFactory()
+        self.group = GroupFactory(members=[self.first_member, self.second_member])
+        self.store = StoreFactory(group=self.group)
+        self.pickup = PickupDateFactory(store=self.store, collectors=[self.first_member])
+
+    def test_new_collector_marks_existing_messages_as_read(self):
+        self.pickup.conversation.messages.create(author=self.first_member, content='foo')
+        self.pickup.conversation.messages.create(author=self.first_member, content='bar')
+
+        PickupDateCollector.objects.create(user=self.second_member, pickupdate=self.pickup)
+
+        new_participant = ConversationParticipant.objects.get(
+            user=self.second_member, conversation=self.pickup.conversation
+        )
+
+        self.assertTrue(new_participant.seen_up_to == self.pickup.conversation.latest_message)


### PR DESCRIPTION
~~Still working on this but here's the current progress. Probably the `ConversationParticipant` logic which sets the `seen_up_to = last_message` could probably live in some function on one of the related models. Will take another look at it soon. Would be good to know if this is going in the right direction :)~~

Ready for a review.

Closes https://github.com/yunity/karrot-frontend/issues/1106.