### PR TITLE
Remove unused group membership manager role & role management API

### DIFF
--- a/foodsaving/groups/api.py
+++ b/foodsaving/groups/api.py
@@ -13,12 +13,12 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from foodsaving.conversations.api import RetrieveConversationMixin
-from foodsaving.groups import roles, stats
+from foodsaving.groups import stats
 from foodsaving.groups.filters import GroupsFilter, GroupsInfoFilter
 from foodsaving.groups.models import Agreement, Group as GroupModel, GroupMembership, Trust
 from foodsaving.groups.serializers import GroupDetailSerializer, GroupPreviewSerializer, GroupJoinSerializer, \
     GroupLeaveSerializer, TimezonesSerializer, EmptySerializer, \
-    GroupMembershipAddRoleSerializer, GroupMembershipRemoveRoleSerializer, GroupMembershipInfoSerializer, \
+    GroupMembershipInfoSerializer, \
     AgreementSerializer, AgreementAgreeSerializer, GroupMembershipAddNotificationTypeSerializer, \
     GroupMembershipRemoveNotificationTypeSerializer
 from foodsaving.utils.mixins import PartialUpdateModelMixin
@@ -36,14 +36,6 @@ class IsOpenGroup(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return obj.is_open
-
-
-class CanUpdateMemberships(BasePermission):
-    message = _('You do not have permission to update memberships.')
-
-    def has_object_permission(self, request, view, obj):
-        # we get a membership object
-        return obj.group.is_member_with_role(request.user, roles.GROUP_MEMBERSHIP_MANAGER)
 
 
 class IsOtherUser(BasePermission):
@@ -151,30 +143,6 @@ class GroupViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin, PartialUp
         membership.save()
         stats.group_activity(membership.group)
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-    @action(
-        detail=True,
-        methods=['PUT', 'DELETE'],
-        permission_classes=(IsAuthenticated, CanUpdateMemberships),
-        url_name='user-roles',
-        url_path='users/(?P<user_id>[^/.]+)/roles/(?P<role_name>[^/.]+)',
-        serializer_class=EmptySerializer  # for Swagger
-    )
-    def modify_user_roles(self, request, pk, user_id, role_name):
-        """add (PUT) or remove (DELETE) a membership role"""
-        self.check_permissions(request)
-        instance = get_object_or_404(GroupMembership.objects, group=pk, user=user_id)
-        self.check_object_permissions(request, instance)
-        serializer_class = None
-        if request.method == 'PUT':
-            serializer_class = GroupMembershipAddRoleSerializer
-        elif request.method == 'DELETE':
-            serializer_class = GroupMembershipRemoveRoleSerializer
-        serializer = serializer_class(instance, data={'role_name': role_name}, partial=True)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
-
-        return Response(GroupMembershipInfoSerializer(instance).data)
 
     @action(
         detail=True,

--- a/foodsaving/groups/receivers.py
+++ b/foodsaving/groups/receivers.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import post_save, pre_delete, post_delete
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
 from foodsaving.conversations.models import Conversation
@@ -54,25 +54,6 @@ def group_member_removed(sender, instance, **kwargs):
         conversation.leave(user)
 
     stats.group_left(group)
-
-
-@receiver(post_save, sender=GroupMembership)
-@receiver(post_delete, sender=GroupMembership)
-def initialize_group(sender, instance, **kwargs):
-    """
-    Configure membership roles for the group.
-
-    This implements a default model of group roles so that there is always someone who can manage the
-    roles and edit the agreement.
-    """
-    group = instance.group
-
-    memberships = GroupMembership.objects.filter(group=group)
-    if not memberships.filter(roles__contains=[roles.GROUP_MEMBERSHIP_MANAGER]).exists():
-        oldest = memberships.order_by('created_at', 'id').first()
-        if oldest:
-            oldest.roles.append(roles.GROUP_MEMBERSHIP_MANAGER)
-            oldest.save()
 
 
 @receiver(post_save, sender=Trust)

--- a/foodsaving/groups/roles.py
+++ b/foodsaving/groups/roles.py
@@ -1,3 +1,2 @@
-GROUP_MEMBERSHIP_MANAGER = 'membership_manager'
 GROUP_AGREEMENT_MANAGER = 'agreement_manager'
 GROUP_EDITOR = 'editor'

--- a/foodsaving/groups/serializers.py
+++ b/foodsaving/groups/serializers.py
@@ -7,7 +7,6 @@ from rest_framework.exceptions import ValidationError, PermissionDenied
 
 from foodsaving.groups.models import Group as GroupModel, GroupMembership, Agreement, UserAgreement, \
     GroupNotificationType
-from foodsaving.groups.roles import GROUP_EDITOR
 from foodsaving.history.models import History, HistoryTypus
 from foodsaving.utils.misc import find_changed
 from foodsaving.utils.validators import prevent_reserved_names
@@ -297,41 +296,6 @@ class TimezonesSerializer(serializers.Serializer):
 
 class EmptySerializer(serializers.Serializer):
     pass
-
-
-class GroupMembershipAddRoleSerializer(serializers.Serializer):
-    role_name = serializers.ChoiceField(
-        choices=(
-            roles.GROUP_MEMBERSHIP_MANAGER,
-            roles.GROUP_AGREEMENT_MANAGER,
-        ), required=True, write_only=True
-    )
-
-    def validate_role_name(self, role_name):
-        if role_name == GROUP_EDITOR:
-            raise serializers.ValidationError('You cannot change the editor role')
-        return role_name
-
-    def update(self, instance, validated_data):
-        role = validated_data['role_name']
-        instance.add_roles([role])
-        instance.save()
-        return instance
-
-
-class GroupMembershipRemoveRoleSerializer(serializers.Serializer):
-    role_name = serializers.CharField(required=True, write_only=True)
-
-    def validate_role_name(self, role_name):
-        if role_name == GROUP_EDITOR:
-            raise serializers.ValidationError('You cannot change the editor role')
-        return role_name
-
-    def update(self, instance, validated_data):
-        role = validated_data['role_name']
-        instance.remove_roles([role])
-        instance.save()
-        return instance
 
 
 class GroupMembershipAddNotificationTypeSerializer(serializers.Serializer):

--- a/foodsaving/groups/tests/test_model.py
+++ b/foodsaving/groups/tests/test_model.py
@@ -3,7 +3,6 @@ from django.db import IntegrityError
 from django.test import TestCase
 
 from foodsaving.conversations.models import Conversation, ConversationParticipant
-from foodsaving.groups import roles
 from foodsaving.groups.factories import GroupFactory, PlaygroundGroupFactory
 from foodsaving.groups.models import Group, GroupMembership, get_default_notification_types
 from foodsaving.users.factories import UserFactory
@@ -18,12 +17,6 @@ class TestGroupModel(TestCase):
         Group.objects.create(name='abcdef')
         with self.assertRaises(IntegrityError):
             Group.objects.create(name='abcdef')
-
-    def test_roles_initialized(self):
-        user = UserFactory()
-        group = GroupFactory(members=[user])
-        membership = GroupMembership.objects.get(user=user, group=group)
-        self.assertIn(roles.GROUP_MEMBERSHIP_MANAGER, membership.roles)
 
     def test_notifications_on_by_default(self):
         user = UserFactory()


### PR DESCRIPTION
It comes from a time where we tried out role hierarchies, but didn't progress with it.

This PR removes all code related to the group membership manager role.

The database still contains `membership_manager` occasionally, could write a migration to remove it.

We might need to role management API in future again (for self-selected roles), but it's unclear how this will look like, so I don't think it's helpful to keep the endpoint around.