### PR TITLE
Add pickup active stats

### DIFF
--- a/foodsaving/groups/models.py
+++ b/foodsaving/groups/models.py
@@ -193,6 +193,9 @@ class GroupMembershipQuerySet(QuerySet):
     def newcomers(self):
         return self.without_role(roles.GROUP_EDITOR)
 
+    def exclude_playgrounds(self):
+        return self.exclude(group__status=GroupStatus.PLAYGROUND)
+
 
 class GroupMembership(BaseModel):
     objects = GroupMembershipQuerySet.as_manager()

--- a/foodsaving/groups/models.py
+++ b/foodsaving/groups/models.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import TextField, DateTimeField, QuerySet
+from django.db.models import TextField, DateTimeField, QuerySet, Subquery, OuterRef
 from django.template.loader import render_to_string
 from django.utils import timezone as tz, timezone
 from timezone_field import TimeZoneField
@@ -14,6 +14,7 @@ from foodsaving.base.base_models import BaseModel, LocationModel
 from foodsaving.conversations.models import ConversationMixin
 from foodsaving.groups import roles
 from foodsaving.history.models import History, HistoryTypus
+from foodsaving.pickups.models import PickupDate
 
 
 class GroupStatus(Enum):
@@ -178,6 +179,13 @@ class GroupMembershipQuerySet(QuerySet):
     def active_within(self, **kwargs):
         now = timezone.now()
         return self.filter(lastseen_at__gte=now - relativedelta(**kwargs))
+
+    def pickup_active_within(self, **kwargs):
+        now = timezone.now()
+        pickups = PickupDate.objects.exclude_disabled().filter(
+            store__group=OuterRef('group'), date__lt=now, date__gte=now - relativedelta(**kwargs)
+        )
+        return self.filter(user__pickup_dates__in=Subquery(pickups.only('pk')))
 
     def editors(self):
         return self.with_role(roles.GROUP_EDITOR)

--- a/foodsaving/groups/stats.py
+++ b/foodsaving/groups/stats.py
@@ -82,10 +82,14 @@ def get_group_members_stats(group):
 
     for n in (1, 7, 30, 60, 90):
         active_memberships = memberships.active_within(days=n)
+        pickup_active_memberships = memberships.pickup_active_within(days=n)
         fields.update({
             'count_active_{}d'.format(n): active_memberships.count(),
             'count_active_newcomers_{}d'.format(n): active_memberships.newcomers().count(),
             'count_active_editors_{}d'.format(n): active_memberships.editors().count(),
+            'count_pickup_active_{}d'.format(n): pickup_active_memberships.count(),
+            'count_pickup_active_newcomers_{}d'.format(n): pickup_active_memberships.newcomers().count(),
+            'count_pickup_active_editors_{}d'.format(n): pickup_active_memberships.editors().count(),
         })
 
     return [{

--- a/foodsaving/pickups/tests/test_data_migrations.py
+++ b/foodsaving/pickups/tests/test_data_migrations.py
@@ -123,4 +123,3 @@ class TestMovedPickupMigration(TestMigrations):
         self.assertEqual(pickups.count(), 1)
         self.assertIsNotNone(pickups[0].series)
         self.assertFalse(pickups[0].deleted)
-

--- a/foodsaving/users/stats.py
+++ b/foodsaving/users/stats.py
@@ -1,4 +1,3 @@
-from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
@@ -14,7 +13,7 @@ def get_users_stats():
     active_membership_count = GroupMembership.objects.active().count()
     active_users_count = active_users.count()
 
-    done_pickup_filter = {'pickup_dates__in':PickupDate.objects.exclude_disabled().filter(date__lt=timezone.now())}
+    done_pickup_filter = {'pickup_dates__in': PickupDate.objects.exclude_disabled().filter(date__lt=timezone.now())}
     pickup_active_users = active_users.filter(**done_pickup_filter)
     pickup_users = User.objects.filter(**done_pickup_filter)
 

--- a/foodsaving/users/stats.py
+++ b/foodsaving/users/stats.py
@@ -1,21 +1,16 @@
 from django.contrib.auth import get_user_model
-from django.utils import timezone
 
 from foodsaving.groups.models import GroupMembership
-from foodsaving.pickups.models import PickupDate
 from foodsaving.webhooks.models import EmailEvent
 
 
 def get_users_stats():
     User = get_user_model()
 
+    # These "active" users use the database inactive_at field (which means 30 days)
     active_users = User.objects.filter(groupmembership__in=GroupMembership.objects.active(), deleted=False).distinct()
     active_membership_count = GroupMembership.objects.active().count()
     active_users_count = active_users.count()
-
-    done_pickup_filter = {'pickup_dates__in': PickupDate.objects.exclude_disabled().filter(date__lt=timezone.now())}
-    pickup_active_users = active_users.filter(**done_pickup_filter)
-    pickup_users = User.objects.filter(**done_pickup_filter)
 
     fields = {
         'active_count': active_users_count,
@@ -28,8 +23,20 @@ def get_users_stats():
         'active_memberships_per_active_user_avg': active_membership_count / active_users_count,
         'no_membership_count': User.objects.filter(groupmembership=None, deleted=False).count(),
         'deleted_count': User.objects.filter(deleted=True).count(),
-        'pickup_active_count': pickup_active_users.count(),
-        'pickup_count': pickup_users.count(),
     }
+
+    for n in (1, 7, 30, 60, 90):
+        active_users = User.objects.filter(
+            groupmembership__in=GroupMembership.objects.exclude_playgrounds().active_within(days=n),
+            deleted=False,
+        ).distinct()
+        pickup_active_users = User.objects.filter(
+            groupmembership__in=GroupMembership.objects.exclude_playgrounds().pickup_active_within(days=n),
+            deleted=False,
+        ).distinct()
+        fields.update({
+            'count_active_{}d'.format(n): active_users.count(),
+            'count_pickup_active_{}d'.format(n): pickup_active_users.count(),
+        })
 
     return fields

--- a/foodsaving/users/stats.py
+++ b/foodsaving/users/stats.py
@@ -1,6 +1,9 @@
+from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 from foodsaving.groups.models import GroupMembership
+from foodsaving.pickups.models import PickupDate
 from foodsaving.webhooks.models import EmailEvent
 
 
@@ -10,6 +13,10 @@ def get_users_stats():
     active_users = User.objects.filter(groupmembership__in=GroupMembership.objects.active(), deleted=False).distinct()
     active_membership_count = GroupMembership.objects.active().count()
     active_users_count = active_users.count()
+
+    done_pickup_filter = {'pickup_dates__in':PickupDate.objects.exclude_disabled().filter(date__lt=timezone.now())}
+    pickup_active_users = active_users.filter(**done_pickup_filter)
+    pickup_users = User.objects.filter(**done_pickup_filter)
 
     fields = {
         'active_count': active_users_count,
@@ -22,6 +29,8 @@ def get_users_stats():
         'active_memberships_per_active_user_avg': active_membership_count / active_users_count,
         'no_membership_count': User.objects.filter(groupmembership=None, deleted=False).count(),
         'deleted_count': User.objects.filter(deleted=True).count(),
+        'pickup_active_count': pickup_active_users.count(),
+        'pickup_count': pickup_users.count(),
     }
 
     return fields

--- a/foodsaving/users/tests/test_stats.py
+++ b/foodsaving/users/tests/test_stats.py
@@ -1,8 +1,11 @@
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 from django.utils import timezone
 
 from foodsaving.groups.factories import GroupFactory
 from foodsaving.groups.models import GroupMembership
+from foodsaving.pickups.factories import PickupDateFactory
+from foodsaving.stores.factories import StoreFactory
 from foodsaving.users import stats
 from foodsaving.users.factories import UserFactory, VerifiedUserFactory
 from foodsaving.webhooks.models import EmailEvent
@@ -12,9 +15,18 @@ class TestUserStats(TestCase):
     def test_user_stats(self):
         self.maxDiff = None
 
+        def do_pickup(store, user, **kwargs):
+            pickup = PickupDateFactory(store=store, date=timezone.now() - relativedelta(**kwargs))
+            pickup.add_collector(user)
+
         # 9 verified users, 1 unverified user
         users = [VerifiedUserFactory() for _ in range(9)]
         users.insert(0, UserFactory())
+
+        # 5 fully inactive users (only in one group and marked as inactive in that group)
+        inactive_users = [VerifiedUserFactory() for _ in range(5)]
+        inactive_group = GroupFactory(members=inactive_users)
+        GroupMembership.objects.filter(group=inactive_group).update(inactive_at=timezone.now())
 
         # 1 deleted user
         deleted_user = UserFactory()
@@ -50,10 +62,19 @@ class TestUserStats(TestCase):
         photo_user.save()
 
         # 2 groups where everybody is active, 1 where everybody is inactive
-        GroupFactory(members=users[:9])
+        group = GroupFactory(members=users[:9])
         GroupFactory(members=users[:9])
         group_all_inactive = GroupFactory(members=users[:9])
         GroupMembership.objects.filter(group=group_all_inactive).update(inactive_at=timezone.now())
+
+        # 1 active user that did a pickup
+        store = StoreFactory(group=group)
+        do_pickup(store, users[0], days=10)
+
+        # 2 inactive user that did a pickup long ago
+        inactive_store = StoreFactory(group=inactive_group)
+        do_pickup(inactive_store, inactive_users[0], days=60)
+        do_pickup(inactive_store, inactive_users[1], days=90)
 
         points = stats.get_users_stats()
 
@@ -69,5 +90,7 @@ class TestUserStats(TestCase):
                 'active_memberships_per_active_user_avg': 2.0,
                 'no_membership_count': 1,
                 'deleted_count': 1,
+                'pickup_active_count': 1,
+                'pickup_count': 3,
             }
         )


### PR DESCRIPTION
Adds stats to keep track of how many users have actually done pickups - as I think this is getting closer to an interesting measure of _real_ activity.

It comes in two parts:

## `karrot.group.members` measurement

This is the _per group_ activity, so about users that have done pickups for a store that's part of that group with the last _n_ days. It does not count other user activity.

New fields:

```
'count_pickup_active_1d': 0,
'count_pickup_active_7d': 1,
'count_pickup_active_30d': 2,
'count_pickup_active_60d': 3,
'count_pickup_active_90d': 4,
'count_pickup_active_editors_1d': 0,
'count_pickup_active_editors_7d': 0,
'count_pickup_active_editors_30d': 1,
'count_pickup_active_editors_60d': 2,
'count_pickup_active_editors_90d': 3,
'count_pickup_active_newcomers_1d': 0,
'count_pickup_active_newcomers_7d': 1,
'count_pickup_active_newcomers_30d': 1,
'count_pickup_active_newcomers_60d': 1,
'count_pickup_active_newcomers_90d': 1,
```
## `karrot.users` measurement

This is for overall user stats, independent of the group.

~~`pickup_count` is users that have done a pickup at any time.
`pickup_active_count` is for active users (_some_ activity in any group within the last 30 days) and have done a pickup at _any_ time (potentially confusing...).~~

~~I think these stats a bit weirder and less useful than the group specific ones :/~~

I made them so they are similar to the group ones.

New fields:

```
 'count_active_1d': 9,
 'count_active_30d': 11,
 'count_active_60d': 12,
 'count_active_7d': 10,
 'count_active_90d': 13,
 'count_pickup_active_1d': 0,
 'count_pickup_active_30d': 2,
 'count_pickup_active_60d': 3,
 'count_pickup_active_7d': 1,
 'count_pickup_active_90d': 4,
```