### PR TITLE
Fixup 2 details of inactive user removal

### DIFF
--- a/foodsaving/groups/api.py
+++ b/foodsaving/groups/api.py
@@ -140,6 +140,7 @@ class GroupViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin, PartialUp
         membership = get_object_or_404(GroupMembership.objects, group=pk, user=request.user)
         membership.lastseen_at = timezone.now()
         membership.inactive_at = None
+        membership.removal_notification_at = None
         membership.save()
         stats.group_activity(membership.group)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/foodsaving/groups/tasks.py
+++ b/foodsaving/groups/tasks.py
@@ -17,6 +17,7 @@ from foodsaving.groups.emails import (
 from foodsaving.groups.models import Group, GroupStatus
 from foodsaving.groups.models import GroupMembership
 from foodsaving.groups.stats import get_group_members_stats, get_group_stores_stats, group_summary_email
+from foodsaving.history.models import History, HistoryTypus
 from foodsaving.utils import stats_utils
 
 
@@ -74,6 +75,11 @@ def process_inactive_users():
     removal_date = now - timedelta(days=settings.NUMBER_OF_DAYS_AFTER_REMOVAL_NOTIFICATION_WE_ACTUALLY_REMOVE_THEM)
     for membership in GroupMembership.objects.filter(removal_notification_at__lte=removal_date):
         membership.delete()
+        History.objects.create(
+            typus=HistoryTypus.GROUP_LEAVE_INACTIVE, group=membership.group, users=[
+                membership.user,
+            ]
+        )
         count_users_removed += 1
 
     stats_utils.periodic_task(

--- a/foodsaving/groups/tests/test_tasks.py
+++ b/foodsaving/groups/tests/test_tasks.py
@@ -11,6 +11,7 @@ from config import settings
 from foodsaving.groups.factories import GroupFactory, PlaygroundGroupFactory, InactiveGroupFactory
 from foodsaving.groups.models import GroupMembership, GroupStatus
 from foodsaving.groups.tasks import process_inactive_users, send_summary_emails, mark_inactive_groups
+from foodsaving.history.models import History, HistoryTypus
 from foodsaving.pickups.factories import PickupDateFactory, FeedbackFactory
 from foodsaving.stores.factories import StoreFactory
 from foodsaving.users.factories import UserFactory, VerifiedUserFactory
@@ -111,9 +112,12 @@ class TestProcessInactiveUsersRemovesOldUsers(TestCase):
 
     def test_removes_old_users(self):
         member = self.group.members.filter(pk=self.inactive_user.id)
+        history = History.objects.filter(typus=HistoryTypus.GROUP_LEAVE_INACTIVE, users__in=[self.inactive_user], group=self.group)
         self.assertTrue(member.exists())
+        self.assertFalse(history.exists())
         process_inactive_users()
         self.assertFalse(member.exists())
+        self.assertTrue(history.exists())
         self.assertEqual(len(mail.outbox), 0)
 
 

--- a/foodsaving/groups/tests/test_tasks.py
+++ b/foodsaving/groups/tests/test_tasks.py
@@ -112,7 +112,9 @@ class TestProcessInactiveUsersRemovesOldUsers(TestCase):
 
     def test_removes_old_users(self):
         member = self.group.members.filter(pk=self.inactive_user.id)
-        history = History.objects.filter(typus=HistoryTypus.GROUP_LEAVE_INACTIVE, users__in=[self.inactive_user], group=self.group)
+        history = History.objects.filter(
+            typus=HistoryTypus.GROUP_LEAVE_INACTIVE, users__in=[self.inactive_user], group=self.group
+        )
         self.assertTrue(member.exists())
         self.assertFalse(history.exists())
         process_inactive_users()

--- a/foodsaving/history/models.py
+++ b/foodsaving/history/models.py
@@ -32,6 +32,7 @@ class HistoryTypus(enum.Enum):
     MEMBER_BECAME_EDITOR = 18
     PICKUP_DISABLE = 19
     PICKUP_ENABLE = 20
+    GROUP_LEAVE_INACTIVE = 21
 
 
 class HistoryQuerySet(models.QuerySet):


### PR DESCRIPTION
1. if user becomes active again we now clear _removal_notification_at_ so we actually do what the email says (at the moment we would still remove them, oops!)
2. add a history entry (with it's own type)