### PR TITLE
Fix pickup active group stats

### DIFF
--- a/foodsaving/groups/models.py
+++ b/foodsaving/groups/models.py
@@ -185,7 +185,7 @@ class GroupMembershipQuerySet(QuerySet):
         pickups = PickupDate.objects.exclude_disabled().filter(
             store__group=OuterRef('group'), date__lt=now, date__gte=now - relativedelta(**kwargs)
         )
-        return self.filter(user__pickup_dates__in=Subquery(pickups.only('pk')))
+        return self.filter(user__pickup_dates__in=Subquery(pickups.only('pk'))).distinct()
 
     def editors(self):
         return self.with_role(roles.GROUP_EDITOR)


### PR DESCRIPTION
I forgot a `distinct()` so the memberships were being counted multiple times making the stats way too high :/