### PR TITLE
Add template processing to sync.py script

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -3,7 +3,10 @@
 import subprocess
 import os
 import glob
+import sys
 from os.path import dirname, realpath, join
+
+process_mjml = '--no-mjml' not in sys.argv[1:]
 
 
 def color(num):
@@ -31,17 +34,19 @@ base = dirname(realpath(__file__))
 header("Installing python dependencies")
 subprocess.run(['pip-sync', 'requirements.txt'], env=environ)
 
-header("Installing node js dependencies")
-subprocess.run(['yarn'], env=environ, cwd=join(base, 'mjml'))
+if process_mjml:
 
-header("Removing old templates")
+    header("Installing node js dependencies")
+    subprocess.run(['yarn'], env=environ, cwd=join(base, 'mjml'))
 
-entries = glob.glob(join(base, 'foodsaving/*/templates/*.html.jinja2'))
-for entry in entries:
-    os.remove(entry)
-print('Removed {} entries'.format(len(entries)))
+    header("Removing old templates")
 
-header("Generating new templates")
-subprocess.run(['./mjml/convert'], env=environ)
+    entries = glob.glob(join(base, 'foodsaving/*/templates/*.html.jinja2'))
+    for entry in entries:
+        os.remove(entry)
+    print('Removed {} entries'.format(len(entries)))
+
+    header("Generating new templates")
+    subprocess.run(['./mjml/convert'], env=environ)
 
 header('All done ☺')

--- a/sync.py
+++ b/sync.py
@@ -2,9 +2,25 @@
 
 import subprocess
 import os
+import glob
+from os.path import dirname, realpath, join
+
 environ = os.environ.copy()
 
 # do not prompt if dependency source already exists, just wipe and get the required version
 environ['PIP_EXISTS_ACTION'] = 'w'
 
+base = dirname(realpath(__file__))
+
+print("★ Installing python dependencies")
 subprocess.run(['pip-sync', 'requirements.txt'], env=environ)
+
+print("★ Installing node js dependencies")
+subprocess.run(['yarn'], env=environ, cwd=join(base, 'mjml'))
+
+print("★ Removing old templates")
+for entry in glob.glob(join(base, 'foodsaving/*/templates/*.html.jinja2')):
+    os.remove(entry)
+
+print("★ Generating new templates")
+subprocess.run(['./mjml/convert'], env=environ)

--- a/sync.py
+++ b/sync.py
@@ -5,6 +5,22 @@ import os
 import glob
 from os.path import dirname, realpath, join
 
+
+def color(num):
+    def format(val):
+        return '\033[' + str(num) + 'm' + val + '\033[0m'
+
+    return format
+
+
+green = color(92)
+yellow = color(93)
+
+
+def header(val):
+    print('\n', yellow('★'), green(val), '\n')
+
+
 environ = os.environ.copy()
 
 # do not prompt if dependency source already exists, just wipe and get the required version
@@ -12,15 +28,20 @@ environ['PIP_EXISTS_ACTION'] = 'w'
 
 base = dirname(realpath(__file__))
 
-print("★ Installing python dependencies")
+header("Installing python dependencies")
 subprocess.run(['pip-sync', 'requirements.txt'], env=environ)
 
-print("★ Installing node js dependencies")
+header("Installing node js dependencies")
 subprocess.run(['yarn'], env=environ, cwd=join(base, 'mjml'))
 
-print("★ Removing old templates")
-for entry in glob.glob(join(base, 'foodsaving/*/templates/*.html.jinja2')):
-    os.remove(entry)
+header("Removing old templates")
 
-print("★ Generating new templates")
+entries = glob.glob(join(base, 'foodsaving/*/templates/*.html.jinja2'))
+for entry in entries:
+    os.remove(entry)
+print('Removed {} entries'.format(len(entries)))
+
+header("Generating new templates")
 subprocess.run(['./mjml/convert'], env=environ)
+
+header('All done ☺')


### PR DESCRIPTION
Currently `./sync.py` just installs the python deps (`pip-sync`), but now it will also install mjml deps, remove the existing templates, and then recompile them.