### PR TITLE
Use timezone when rendering emails

### DIFF
--- a/foodsaving/applications/emails.py
+++ b/foodsaving/applications/emails.py
@@ -22,6 +22,7 @@ def prepare_new_application_notification_email(user, application):
         template='new_application',
         from_email=from_email,
         user=user,
+        tz=application.group.timezone,
         reply_to=[reply_to],
         unsubscribe_url=unsubscribe_url,
         context={
@@ -42,6 +43,7 @@ def prepare_application_accepted_email(application):
     return prepare_email(
         template='application_accepted',
         user=application.user,
+        tz=application.group.timezone,
         context={
             'group': application.group,
             'group_url': group_wall_url(application.group)
@@ -53,6 +55,7 @@ def prepare_application_declined_email(application):
     return prepare_email(
         template='application_declined',
         user=application.user,
+        tz=application.group.timezone,
         context={
             'group': application.group,
         },

--- a/foodsaving/conversations/emails.py
+++ b/foodsaving/conversations/emails.py
@@ -55,6 +55,7 @@ def prepare_group_thread_message_notification(user, messages):
         template='thread_message_notification',
         from_email=from_email,
         user=user,
+        tz=group.timezone,
         reply_to=[reply_to],
         unsubscribe_url=unsubscribe_url,
         context={
@@ -86,6 +87,7 @@ def prepare_group_conversation_message_notification(user, message):
         template='conversation_message_notification',
         from_email=from_email,
         user=user,
+        tz=group.timezone,
         reply_to=[reply_to],
         unsubscribe_url=unsubscribe_url,
         context={
@@ -149,6 +151,7 @@ def prepare_pickup_conversation_message_notification(user, messages):
                 template='conversation_message_notification',
                 from_email=from_email,
                 user=user,
+                tz=group_tz,
                 reply_to=[reply_to],
                 unsubscribe_url=unsubscribe_url,
                 context={
@@ -176,6 +179,7 @@ def prepare_private_user_conversation_message_notification(user, messages):
         template='conversation_message_notification',
         from_email=from_email,
         user=user,
+        # TODO: which timezone? maybe the user needs a timezone?
         reply_to=[reply_to],
         unsubscribe_url=unsubscribe_url,
         context={
@@ -220,6 +224,7 @@ def prepare_application_message_notification(user, messages):
             template='conversation_message_notification',
             from_email=from_email,
             user=user,
+            tz=application.group.timezone,
             reply_to=[reply_to],
             unsubscribe_url=unsubscribe_url,
             context={
@@ -260,6 +265,7 @@ def prepare_issue_message_notification(user, messages):
             template='conversation_message_notification',
             from_email=from_email,
             user=user,
+            tz=issue.group.timezone,
             reply_to=[reply_to],
             unsubscribe_url=unsubscribe_url,
             context={

--- a/foodsaving/groups/emails.py
+++ b/foodsaving/groups/emails.py
@@ -69,6 +69,7 @@ def prepare_group_summary_emails(group, context):
     return [
         prepare_email(
             template='group_summary',
+            tz=group.timezone,
             context={
                 'unsubscribe_url': group_summary_unsubscribe_url(member, group),
                 **context,
@@ -99,6 +100,7 @@ def prepare_user_inactive_in_group_email(user, group):
     return prepare_email(
         template='user_inactive_in_group',
         user=user,
+        tz=group.timezone,
         context={
             'group_name': group.name,
             'group_url': group_wall_url(group),
@@ -111,6 +113,7 @@ def prepare_user_removal_from_group_email(user, group):
     return prepare_email(
         template='user_removal_from_group',
         user=user,
+        tz=group.timezone,
         context={
             'group_name': group.name,
             'group_url': group_wall_url(group),
@@ -124,6 +127,7 @@ def prepare_user_became_editor_email(user, group):
     return prepare_email(
         template='user_became_editor',
         user=user,
+        tz=group.timezone,
         context={
             'group_name': group.name,
             'group_url': group_wall_url(group),

--- a/foodsaving/invitations/emails.py
+++ b/foodsaving/invitations/emails.py
@@ -6,6 +6,7 @@ def prepare_emailinvitation_email(invitation):
     return prepare_email(
         template='emailinvitation',
         user=None,
+        tz=invitation.group.timezone,
         context={
             'group_name': invitation.group.name,
             'invite_url': invite_url(invitation),

--- a/foodsaving/issues/emails.py
+++ b/foodsaving/issues/emails.py
@@ -23,6 +23,7 @@ def prepare_new_conflict_resolution_email_to_affected_user(issue):
         template='new_conflict_resolution_affected_user',
         from_email=from_email,
         user=user,
+        tz=issue.group.timezone,
         reply_to=[reply_to],
         context={
             'created_by': created_by,
@@ -53,6 +54,7 @@ def prepare_new_conflict_resolution_email(user, issue):
         template='new_conflict_resolution',
         from_email=from_email,
         user=user,
+        tz=issue.group.timezone,
         reply_to=[reply_to],
         unsubscribe_url=unsubscribe_url,
         context={
@@ -77,6 +79,7 @@ def prepare_conflict_resolution_continued_email(user, issue):
     return prepare_email(
         template='conflict_resolution_continued',
         user=user,
+        tz=issue.group.timezone,
         context={
             'affected_user': affected_user,
             'unsubscribe_url': unsubscribe_url,
@@ -95,6 +98,7 @@ def prepare_conflict_resolution_continued_email_to_affected_user(issue):
     return prepare_email(
         template='conflict_resolution_continued_affected_user',
         user=user,
+        tz=issue.group.timezone,
         context={
             'conflict_resolution_url': issue_url,
             'expires_at': voting.expires_at,

--- a/foodsaving/pickups/emails.py
+++ b/foodsaving/pickups/emails.py
@@ -34,6 +34,7 @@ def prepare_pickup_notification_email(
     return prepare_email(
         template='pickup_notification',
         user=user,
+        tz=group.timezone,
         context={
             'unsubscribe_url': unsubscribe_url,
             'group': group,

--- a/foodsaving/utils/email_utils.py
+++ b/foodsaving/utils/email_utils.py
@@ -64,17 +64,10 @@ class StatCollectingAnymailMessage(AnymailMessage):
 
 
 def prepare_email(
-        template,
-        user=None,
-        context=None,
-        to=None,
-        tz=timezone.utc,
-        language=None,
-        unsubscribe_url=None,
-        transactional=False,
-        **kwargs,
+        template, user=None, context=None, to=None, language=None, unsubscribe_url=None, transactional=False, **kwargs
 ):
     context = dict(context) if context else {}
+    tz = kwargs.pop('tz', timezone.utc)
 
     default_context = {
         'site_name': settings.SITE_NAME,


### PR DESCRIPTION
Fixes https://github.com/yunity/karrot-frontend/issues/1083

I noticed we didn't really specify the timezone much when rendering emails - I added it as a parameter to the `prepare_email()` function now to encourage it to be passed through (defaults to utc) and eventually call `with timezone.override()` just as it renders the template.

The other option would have been to put the email preparing inside a `with timezone.override()` much higher up for each case, but found it cleaner to pass it in directly (and revealed it's not very clear which timezone should be for private messages, as they are outside the context of a group).