### PR TITLE
add support for discourse email_reply_trimmer

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -280,6 +280,10 @@ HUEY = {
     'always_eager': True,
 }
 
+# If you have the email_reply_trimmer_service running, set this to 'http://localhost:4567/trim' (or similar)
+# https://github.com/yunity/email_reply_trimmer_service
+EMAIL_REPLY_TRIMMER_URL = None
+
 if 'USE_SILK' in os.environ:
     INSTALLED_APPS += ('silk', )
     MIDDLEWARE = ('silk.middleware.SilkyMiddleware', ) + MIDDLEWARE

--- a/karrot/webhooks/api.py
+++ b/karrot/webhooks/api.py
@@ -1,14 +1,12 @@
 import binascii
 
-import requests
 from anymail.exceptions import AnymailAPIError
 from base64 import b64decode, b32decode, b32encode
-from email.utils import parseaddr
-from raven.contrib.django.raven_compat.models import client as sentry_client
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import signing
+from email.utils import parseaddr
+from raven.contrib.django.raven_compat.models import client as sentry_client
 from rest_framework import views, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response

--- a/karrot/webhooks/stats.py
+++ b/karrot/webhooks/stats.py
@@ -8,3 +8,10 @@ def incoming_email_rejected():
             'incoming_email_rejected': 1,
         },
     }])
+
+
+def incoming_email_trimmed(fields):
+    write_points([{
+        'measurement': 'karrot.incoming_email',
+        'fields': fields,
+    }])

--- a/karrot/webhooks/utils.py
+++ b/karrot/webhooks/utils.py
@@ -3,6 +3,8 @@ import requests
 from django.conf import settings
 from talon import quotations
 
+from raven.contrib.django.raven_compat.models import client as sentry_client
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,8 @@ def trim_with_discourse(text):
             timeout=2,
         ).json()
     except requests.exceptions.ConnectionError:
-        logger.warning('email_reply_trimmer not accessible at ' + settings.EMAIL_REPLY_TRIMMER_URL + ', skipping.')
+        logger.warning('EMAIL_REPLY_TRIMMER_URL not accessible at ' + settings.EMAIL_REPLY_TRIMMER_URL + ', skipping.')
+        sentry_client.captureException()
         trimmed = text
     else:
         trimmed = response['trimmed']

--- a/karrot/webhooks/utils.py
+++ b/karrot/webhooks/utils.py
@@ -1,0 +1,34 @@
+import logging
+import requests
+from django.conf import settings
+from talon import quotations
+
+logger = logging.getLogger(__name__)
+
+
+def trim_with_talon(text):
+    trimmed = quotations.extract_from_plain(text)
+
+    return trimmed, len(trimmed.splitlines())
+
+
+def trim_with_discourse(text):
+    if settings.EMAIL_REPLY_TRIMMER_URL is None:
+        logger.info('EMAIL_REPLY_TRIMMER_URL not set, skipping.')
+        return text, len(text.splitlines())
+
+    try:
+        response = requests.post(
+            settings.EMAIL_REPLY_TRIMMER_URL,
+            json={
+                'text': text
+            },
+            timeout=2,
+        ).json()
+    except requests.exceptions.ConnectionError:
+        logger.warning('email_reply_trimmer not accessible at ' + settings.EMAIL_REPLY_TRIMMER_URL + ', skipping.')
+        trimmed = text
+    else:
+        trimmed = response['trimmed']
+
+    return trimmed, len(trimmed.splitlines())


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/1096

`email_reply_trimmer` works better than `talon` in almost all cases, for a few exceptions. In all cases, it seems safe to choose the trimmed reply that has less lines.

To enable, configure `EMAIL_REPLY_TRIMMER_URL` in `local_settings.py`.

If the service goes down, it should cause no error. Maybe we should send a warning to sentry though.

It still needs some changes to our ansible setup to deploy the docker container: https://github.com/yunity/email_reply_trimmer_service