### PR TITLE
Support duration for one-time pickups

### DIFF
--- a/karrot/pickups/models.py
+++ b/karrot/pickups/models.py
@@ -306,6 +306,14 @@ class PickupDate(BaseModel, ConversationMixin):
             user=user,
         ).delete()
 
+    def save(self, *args, **kwargs):
+        if not self.has_duration:
+            # reset duration to default if pickup has no explicit duration
+            start = self.date.start
+            self.date = CustomDateTimeTZRange(start, start + default_duration)
+
+        super().save(*args, **kwargs)
+
 
 class PickupDateCollector(BaseModel):
     pickupdate = models.ForeignKey(

--- a/karrot/pickups/serializers.py
+++ b/karrot/pickups/serializers.py
@@ -75,7 +75,6 @@ class PickupDateSerializer(serializers.ModelSerializer):
             'id',
             'series',
             'collectors',
-            'has_duration',
             'is_done',
         ]
 
@@ -170,6 +169,11 @@ class PickupDateUpdateSerializer(PickupDateSerializer):
         if self.instance.series is not None and abs((self.instance.date.start - date.start).total_seconds()) > 1:
             raise serializers.ValidationError(_('You can\'t move pickups that are part of a series.'))
         return super().validate_date(date)
+
+    def validate_has_duration(self, has_duration):
+        if self.instance.series is not None and has_duration != self.instance.has_duration:
+            raise serializers.ValidationError('You cannot modify the duration of pickups that are part of a series')
+        return has_duration
 
 
 class PickupDateJoinSerializer(serializers.ModelSerializer):

--- a/karrot/pickups/tests/test_pickupdate_series_api.py
+++ b/karrot/pickups/tests/test_pickupdate_series_api.py
@@ -489,6 +489,21 @@ class TestPickupDateSeriesChangeAPI(APITestCase, ExtractPaginationMixin):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('You can\'t move pickups', response.data['date'][0])
 
+    def test_cannot_change_pickup_has_duration_in_a_series(self):
+        self.client.force_login(user=self.member)
+        pickup = self.series.pickup_dates.last()
+
+        response = self.client.patch(
+            '/api/pickup-dates/{}/'.format(pickup.id),
+            {'has_duration': True},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            'You cannot modify the duration of pickups that are part of a series', response.data['has_duration'][0]
+        )
+
 
 class TestPickupDateSeriesAPIAuth(APITestCase):
     """ Testing actions that are forbidden """


### PR DESCRIPTION
It looks like the code was in an inconsistent state: `has_duration` of single pickups could never become `True` via API, even when start and end date were further then 30 minutes apart.

This PR:
- adds support for setting `has_duration` via pickup-date API
- resets end date to 30 minutes when `has_duration` is set to `False`
- prevents changing `has_duration` when the pickup is part of a series
