### PR TITLE
Create offer transactionally

### DIFF
--- a/karrot/groups/factories.py
+++ b/karrot/groups/factories.py
@@ -17,7 +17,10 @@ class GroupFactory(DjangoModelFactory):
         if created and extracted:
             for member in extracted:
                 membership = self.groupmembership_set.create(user=member, roles=[roles.GROUP_EDITOR])
-                membership.add_notification_types([GroupNotificationType.NEW_APPLICATION])
+                membership.add_notification_types([
+                    GroupNotificationType.NEW_APPLICATION,
+                    GroupNotificationType.NEW_OFFER,
+                ])
                 membership.save()
 
     @post_generation

--- a/karrot/groups/tests/test_stats.py
+++ b/karrot/groups/tests/test_stats.py
@@ -87,6 +87,7 @@ class TestGroupStats(TestCase):
                     'count_newcomers_total': 1,
                     'count_active_30d_with_notification_type_weekly_summary': 7,
                     'count_active_30d_with_notification_type_new_application': 7,
+                    'count_active_30d_with_notification_type_new_offer': 7,
                     'count_active_30d_with_notification_type_daily_pickup_notification': 7,
                 },
             }]

--- a/karrot/offers/receivers.py
+++ b/karrot/offers/receivers.py
@@ -14,12 +14,6 @@ def offer_saved(sender, instance, created, **kwargs):
         conversation = Conversation.objects.get_or_create_for_target(offer)
         conversation.join(offer.user)
 
-        def notify():
-            notify_members_about_new_offer(offer)
-
         # offer saving is normally done in a transaction so as to include the images
         # we only want to trigger the notification after this transaction is complete
-        if transaction.get_connection().in_atomic_block:
-            transaction.on_commit(notify)
-        else:
-            notify()
+        transaction.on_commit(lambda: notify_members_about_new_offer(offer))

--- a/karrot/offers/serializers.py
+++ b/karrot/offers/serializers.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
@@ -61,9 +62,12 @@ class OfferSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         images = validated_data.pop('images')
-        offer = Offer.objects.create(**validated_data)
-        for image in images:
-            OfferImage.objects.create(offer=offer, **image)
+        # Save the offer and it's associated images in one transaction
+        # Allows us to trigger the notifications in the receiver only after all is saved
+        with transaction.atomic():
+            offer = Offer.objects.create(**validated_data)
+            for image in images:
+                OfferImage.objects.create(offer=offer, **image)
         stats.offer_created(offer)
         return offer
 

--- a/karrot/offers/serializers.py
+++ b/karrot/offers/serializers.py
@@ -62,7 +62,7 @@ class OfferSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         images = validated_data.pop('images')
-        # Save the offer and it's associated images in one transaction
+        # Save the offer and its associated images in one transaction
         # Allows us to trigger the notifications in the receiver only after all is saved
         with transaction.atomic():
             offer = Offer.objects.create(**validated_data)

--- a/karrot/offers/tests/test_api.py
+++ b/karrot/offers/tests/test_api.py
@@ -1,13 +1,14 @@
 import json
 import os
 from io import StringIO
+from unittest.mock import patch
 
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APITransactionTestCase
 
 from karrot.groups.factories import GroupFactory
 from karrot.offers.factories import OfferFactory
-from karrot.users.factories import UserFactory
+from karrot.users.factories import UserFactory, VerifiedUserFactory
 from karrot.utils.tests.fake import faker
 
 image_path = os.path.join(os.path.dirname(__file__), './photo.jpg')
@@ -163,6 +164,31 @@ class TestOffersAPI(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         by_id = {image['id']: image for image in response.data['images']}
         self.assertEqual(by_id[image_id]['position'], new_position)
+
+
+@patch('karrot.offers.emails.prepare_email')
+class TestOffersTransactionAPI(APITransactionTestCase):
+    def setUp(self):
+        self.user = VerifiedUserFactory()
+        self.another_user = VerifiedUserFactory()
+        self.group = GroupFactory(members=[self.user, self.another_user])
+
+    def test_create_offer(self, prepare_email):
+        self.client.force_login(user=self.user)
+        with open(image_path, 'rb') as image_file:
+            data = {
+                'name': faker.name(),
+                'description': faker.text(),
+                'group': self.group.id,
+                'images': [{
+                    'position': 0,
+                    'image': image_file
+                }],
+            }
+            response = self.client.post('/api/offers/', data=encode_offer_data(data))
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            kwargs = prepare_email.call_args.kwargs
+            self.assertIsNotNone(kwargs['context']['offer_photo'])
 
 
 class TestListOffersAPI(APITestCase):

--- a/karrot/offers/tests/test_api.py
+++ b/karrot/offers/tests/test_api.py
@@ -187,7 +187,7 @@ class TestOffersTransactionAPI(APITransactionTestCase):
             }
             response = self.client.post('/api/offers/', data=encode_offer_data(data))
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-            kwargs = prepare_email.call_args.kwargs
+            args, kwargs = prepare_email.call_args
             self.assertIsNotNone(kwargs['context']['offer_photo'])
 
 

--- a/karrot/unsubscribe/tests/test_unsubscribe.py
+++ b/karrot/unsubscribe/tests/test_unsubscribe.py
@@ -89,6 +89,7 @@ class TestUnsubscribeFromAllConversationsInGroup(TestCase):
                 'weekly_summary',
                 'daily_pickup_notification',
                 'new_application',
+                'new_offer',
             ]
         )
         unsubscribe_from_all_conversations_in_group(self.user, self.group)


### PR DESCRIPTION
We create offers with their images. But using our normal signals method to trigger the notifications, they would get triggered without their associated images available (see https://sentry.io/organizations/foodsaving-worldwide/issues/1345296602/).

This PR makes it so we create the offer and it's images inside a transaction. That doesn't entirely solve it though as the post_save signal is still triggered during the transaction. But we can use the `transaction.on_commit` hook if we are in a transaction to only trigger the notification when the transaction is closed.

If we had to do this is many places it might be nice to wrap it up into an abstraction, but at least for now this is the only model that has dependent models like that.