### PR TITLE
Avoid high number of values per tag in influxdb

### DIFF
--- a/karrot/stats/serializers.py
+++ b/karrot/stats/serializers.py
@@ -15,7 +15,6 @@ class StatsEntrySerializer(serializers.Serializer):
     group = serializers.IntegerField(allow_null=True)
     route_name = serializers.CharField()
     route_path = serializers.CharField()
-    route_params = serializers.DictField(allow_empty=True)
 
     # device/build info
     mobile = serializers.BooleanField()

--- a/karrot/stats/stats.py
+++ b/karrot/stats/stats.py
@@ -5,6 +5,7 @@ def convert_stat(stat):
     tags = dict(stat)
     ms = tags.pop('ms')
     ms_resources = tags.pop('ms_resources')
+    route_path = tags.pop('route_path')
     route_params = tags.pop('route_params')
     for key, value in route_params.items():
         tags['route_params__{}'.format(key)] = value
@@ -13,6 +14,8 @@ def convert_stat(stat):
         'fields': {
             'ms': ms,
             'ms_resources': ms_resources,
+            # Put route_path as field to avoid hitting max-values-per-tag limit in influxdb
+            'route_path': route_path,
         },
         'tags': tags,
     }

--- a/karrot/stats/stats.py
+++ b/karrot/stats/stats.py
@@ -6,9 +6,6 @@ def convert_stat(stat):
     ms = tags.pop('ms')
     ms_resources = tags.pop('ms_resources')
     route_path = tags.pop('route_path')
-    route_params = tags.pop('route_params')
-    for key, value in route_params.items():
-        tags['route_params__{}'.format(key)] = value
     return {
         'measurement': 'karrot.stats.frontend',
         'fields': {

--- a/karrot/stats/tests/test_api.py
+++ b/karrot/stats/tests/test_api.py
@@ -21,9 +21,6 @@ def generate_stats(n):
         'group': random.choice([random.randint(1, 100), None]),
         'route_name': faker.name(),
         'route_path': faker.name(),
-        'route_params': {
-            'group_id': 3,
-        }
     } for n in range(n)]
 
 
@@ -71,8 +68,6 @@ class TestStatsInfoAPI(APITestCase):
                     'dev': False,
                     'group': 1,
                     'route_name': 'group',
-                    'route_params__group_id': 5,
-                    'route_params__foo': 'bar',
                 }
             }]
         )

--- a/karrot/stats/tests/test_api.py
+++ b/karrot/stats/tests/test_api.py
@@ -52,28 +52,30 @@ class TestStatsInfoAPI(APITestCase):
         response = self.client.post('/api/stats/', data={'stats': [stat]}, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
         self.assertEqual(len(write_points.call_args_list), 1)
-        (points,), kwargs = write_points.call_args
-        self.assertEqual(points, [{
-            'measurement': 'karrot.stats.frontend',
-            'fields': {
-                'ms': stat['ms'],
-                'ms_resources': stat['ms_resources'],
-            },
-            'tags': {
-                'first_load': True,
-                'logged_in': True,
-                'mobile': False,
-                'app': False,
-                'browser': 'firefox',
-                'os': 'linux',
-                'dev': False,
-                'group': 1,
-                'route_name': 'group',
-                'route_path': '/group',
-                'route_params__group_id': 5,
-                'route_params__foo': 'bar',
-            }
-        }])
+        (points, ), kwargs = write_points.call_args
+        self.assertEqual(
+            points, [{
+                'measurement': 'karrot.stats.frontend',
+                'fields': {
+                    'ms': stat['ms'],
+                    'ms_resources': stat['ms_resources'],
+                    'route_path': '/group',
+                },
+                'tags': {
+                    'first_load': True,
+                    'logged_in': True,
+                    'mobile': False,
+                    'app': False,
+                    'browser': 'firefox',
+                    'os': 'linux',
+                    'dev': False,
+                    'group': 1,
+                    'route_name': 'group',
+                    'route_params__group_id': 5,
+                    'route_params__foo': 'bar',
+                }
+            }]
+        )
 
     def test_writing_many_points(self, write_points):
         n = 50
@@ -81,7 +83,7 @@ class TestStatsInfoAPI(APITestCase):
         response = self.client.post('/api/stats/', data={'stats': stats}, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
         self.assertEqual(len(write_points.call_args_list), 1)
-        (points,), kwargs = write_points.call_args
+        (points, ), kwargs = write_points.call_args
         self.assertEqual(len(points), n)
 
     def test_writing_too_many_points(self, write_points):


### PR DESCRIPTION
Background: https://github.com/bitlabstudio/django-influxdb-metrics/issues/27

route_path may contain many different values because it contains many IDs, so we shouldn't keep it as tag.

route_params may also grow in size (especially with something like so pickup_ids). We should keep an eye on it.