### PR TITLE
Default to enable conflict resolution notifications

### DIFF
--- a/karrot/groups/models.py
+++ b/karrot/groups/models.py
@@ -225,6 +225,7 @@ def get_default_notification_types():
     return [
         GroupNotificationType.WEEKLY_SUMMARY,
         GroupNotificationType.DAILY_PICKUP_NOTIFICATION,
+        GroupNotificationType.CONFLICT_RESOLUTION,
     ]
 
 

--- a/karrot/groups/tests/test_stats.py
+++ b/karrot/groups/tests/test_stats.py
@@ -89,6 +89,7 @@ class TestGroupStats(TestCase):
                     'count_active_30d_with_notification_type_new_application': 7,
                     'count_active_30d_with_notification_type_new_offer': 7,
                     'count_active_30d_with_notification_type_daily_pickup_notification': 7,
+                    'count_active_30d_with_notification_type_conflict_resolution': 7,
                 },
             }]
         )

--- a/karrot/issues/migrations/0004_enable_issue_notifications.py
+++ b/karrot/issues/migrations/0004_enable_issue_notifications.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+def enable_issue_notifications(apps, schema_editor):
+    GroupMembership = apps.get_model('groups', 'GroupMembership')
+    for membership in GroupMembership.objects.exclude(notification_types__contains=['conflict_resolution']):
+        membership.notification_types.append('conflict_resolution')
+        membership.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('issues', '0003_issue_status_changed_at'),
+    ]
+
+    operations = [migrations.RunPython(enable_issue_notifications, migrations.RunPython.noop, elidable=True)]

--- a/karrot/issues/tests/test_data_migrations.py
+++ b/karrot/issues/tests/test_data_migrations.py
@@ -1,0 +1,39 @@
+from karrot.tests.utils import TestMigrations
+from karrot.utils.tests.fake import faker
+
+
+class TestEnableIssueNotifications(TestMigrations):
+    migrate_from = [
+        ('groups', '0042_auto_20200507_1258'),
+        ('users', '0022_auto_20190404_1919'),
+        ('issues', '0003_issue_status_changed_at'),
+    ]
+    migrate_to = [
+        ('issues', '0004_enable_issue_notifications'),
+    ]
+
+    def setUpBeforeMigration(self, apps):
+        Group = apps.get_model('groups', 'Group')
+        GroupMembership = apps.get_model('groups', 'GroupMembership')
+        User = apps.get_model('users', 'User')
+        group = Group.objects.create(name=faker.name())
+        user1 = User.objects.create()
+        user2 = User.objects.create()
+        membership1 = GroupMembership.objects.create(group=group, user=user1, notification_types=[])
+        membership2 = GroupMembership.objects.create(
+            group=group, user=user2, notification_types=['conflict_resolution', 'other', 'stuff']
+        )
+        self.assertEqual(membership1.notification_types, [])
+        self.assertEqual(membership2.notification_types, ['conflict_resolution', 'other', 'stuff'])
+        self.membership1_id = membership1.id
+        self.membership2_id = membership2.id
+
+    def test_enables_issue_notifications(self):
+        GroupMembership = self.apps.get_model('groups', 'GroupMembership')
+        membership1 = GroupMembership.objects.get(pk=self.membership1_id)
+        self.assertEqual(membership1.notification_types, ['conflict_resolution'])
+
+    def test_keeps_other_notification_types(self):
+        GroupMembership = self.apps.get_model('groups', 'GroupMembership')
+        membership2 = GroupMembership.objects.get(pk=self.membership2_id)
+        self.assertEqual(membership2.notification_types, ['conflict_resolution', 'other', 'stuff'])

--- a/karrot/unsubscribe/tests/test_unsubscribe.py
+++ b/karrot/unsubscribe/tests/test_unsubscribe.py
@@ -88,6 +88,7 @@ class TestUnsubscribeFromAllConversationsInGroup(TestCase):
             membership.get().notification_types, [
                 'weekly_summary',
                 'daily_pickup_notification',
+                'conflict_resolution',
                 'new_application',
                 'new_offer',
             ]


### PR DESCRIPTION
See https://github.com/yunity/karrot-frontend/issues/2043

Open question for now: should I create a db migration to enable that setting for everyone?

I think yes. _But_ it does mean anybody that explicitly set it to off (e.g. they maybe turned it on for a while, then turned it off) will have their preference ignored. _Buuuut_ I suspect that is very few cases, as there are not many issues in the first place.
