### PR TITLE
Fix pickup notification unsubscribe link

### DIFF
--- a/karrot/pickups/emails.py
+++ b/karrot/pickups/emails.py
@@ -1,5 +1,5 @@
 from karrot.utils.email_utils import prepare_email
-from karrot.utils.frontend_urls import weekly_summary_unsubscribe_url
+from karrot.utils.frontend_urls import pickup_notification_unsubscribe_url
 
 
 def prepare_pickup_notification_email(
@@ -29,7 +29,7 @@ def prepare_pickup_notification_email(
         ]
     ])
 
-    unsubscribe_url = weekly_summary_unsubscribe_url(user, group)
+    unsubscribe_url = pickup_notification_unsubscribe_url(user, group)
 
     return prepare_email(
         template='pickup_notification',

--- a/karrot/utils/frontend_urls.py
+++ b/karrot/utils/frontend_urls.py
@@ -64,8 +64,8 @@ def pickup_detail_url(pickup):
     )
 
 
-def weekly_summary_unsubscribe_url(user, group):
-    return unsubscribe_url(user, group, notification_type=GroupNotificationType.WEEKLY_SUMMARY)
+def pickup_notification_unsubscribe_url(user, group):
+    return unsubscribe_url(user, group, notification_type=GroupNotificationType.DAILY_PICKUP_NOTIFICATION)
 
 
 def group_summary_unsubscribe_url(user, group):


### PR DESCRIPTION
Seemed totally broken in that the daily pickup notification email unsubscribe link went to unsubscribe from the weekly notification email ... (I noticed it from trying to unsubscribe to them myself).