### PR TITLE
Simple retry for emails

### DIFF
--- a/karrot/utils/stats.py
+++ b/karrot/utils/stats.py
@@ -14,6 +14,19 @@ def email_sent(recipient_count, category):
     }])
 
 
+def email_retry(recipient_count, category):
+    write_points([{
+        'measurement': 'karrot.email.retry',
+        'tags': {
+            'category': category,
+        },
+        'fields': {
+            'value': 1,
+            'recipient_count': recipient_count
+        },
+    }])
+
+
 def email_error(recipient_count, category):
     write_points([{
         'measurement': 'karrot.email.error',


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/1985

Retry sending emails 2 times if `AnymailAPIError` was raised. This should help in cases where Postal is overloaded. 

As it retries immediately, this does not help if Postal is down. I think this is a separate problem and maybe one we don't need to solve in Karrot.
