### PR TITLE
Remove email suppression

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -196,11 +196,6 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # don't send out email by default, override in local_settings.py
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-EMAIL_EVENTS_AVOID = [
-    'bounce', 'out_of_band', 'policy_rejection',  # native sparkpost events
-    'rejected', 'bounced',  # anymail tracking event types
-]
-
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.Argon2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',

--- a/karrot/applications/tasks.py
+++ b/karrot/applications/tasks.py
@@ -16,7 +16,7 @@ def notify_members_about_new_application(application):
             GroupNotificationType.NEW_APPLICATION
         ),
     ).exclude(
-        id__in=get_user_model().objects.unverified_or_ignored(),
+        id__in=get_user_model().objects.unverified(),
     )
 
     for user in users:

--- a/karrot/conversations/tasks.py
+++ b/karrot/conversations/tasks.py
@@ -47,7 +47,7 @@ def get_participants_to_notify(message):
     return participants_to_notify.exclude(
         user=message.author,
     ).exclude(
-        user__in=User.objects.unverified_or_ignored(),
+        user__in=User.objects.unverified(),
     ).exclude(
         seen_up_to__id__gte=message.id,
     ).exclude(

--- a/karrot/groups/emails.py
+++ b/karrot/groups/emails.py
@@ -64,7 +64,7 @@ def prepare_group_summary_emails(group, context):
     members = group.members.filter(
         groupmembership__in=GroupMembership.objects.active().
         with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
-    ).exclude(groupmembership__user__in=get_user_model().objects.unverified_or_ignored())
+    ).exclude(groupmembership__user__in=get_user_model().objects.unverified())
 
     return [
         prepare_email(

--- a/karrot/groups/tests/test_emails.py
+++ b/karrot/groups/tests/test_emails.py
@@ -52,7 +52,7 @@ class TestGroupSummaryEmails(APITestCase):
         expected_members = self.group.members.filter(
             groupmembership__in=GroupMembership.objects.active().
             with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
-        ).exclude(groupmembership__user__in=get_user_model().objects.unverified_or_ignored())
+        ).exclude(groupmembership__user__in=get_user_model().objects.unverified())
 
         self.assertEqual(
             sorted([email.to[0] for email in emails]), sorted([member.email for member in expected_members])
@@ -83,7 +83,7 @@ class TestGroupSummaryEmails(APITestCase):
         expected_members = self.group.members.filter(
             groupmembership__in=GroupMembership.objects.active().
             with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
-        ).exclude(groupmembership__user__in=get_user_model().objects.unverified_or_ignored())
+        ).exclude(groupmembership__user__in=get_user_model().objects.unverified())
 
         self.assertEqual(sorted(to), sorted([member.email for member in expected_members]))
 
@@ -103,7 +103,7 @@ class TestGroupSummaryEmails(APITestCase):
         expected_members = self.group.members.filter(
             groupmembership__in=GroupMembership.objects.active().
             with_notification_type(GroupNotificationType.WEEKLY_SUMMARY)
-        ).exclude(groupmembership__user__in=get_user_model().objects.unverified_or_ignored())
+        ).exclude(groupmembership__user__in=get_user_model().objects.unverified())
 
         self.assertEqual(
             sorted([email.to[0] for email in emails]), sorted([member.email for member in expected_members])

--- a/karrot/issues/tasks.py
+++ b/karrot/issues/tasks.py
@@ -36,7 +36,7 @@ def get_users_to_notify(issue):
     return issue.participants.filter(
         groupmembership__notification_types__contains=[GroupNotificationType.CONFLICT_RESOLUTION],
         groupmembership__inactive_at__isnull=True,
-    ).exclude(id__in=get_user_model().objects.unverified_or_ignored()).distinct()
+    ).exclude(id__in=get_user_model().objects.unverified()).distinct()
 
 
 def send_or_report_error(email):

--- a/karrot/offers/tasks.py
+++ b/karrot/offers/tasks.py
@@ -12,10 +12,8 @@ def notify_members_about_new_offer(offer):
     users = offer.group.members.filter(
         groupmembership__in=GroupMembership.objects.active().with_notification_type(GroupNotificationType.NEW_OFFER),
     ).exclude(
-        id__in=get_user_model().objects.unverified_or_ignored(),
-    ).exclude(
-        id=offer.user.id
-    )
+        id__in=get_user_model().objects.unverified(),
+    ).exclude(id=offer.user.id)
 
     for user in users:
         try:

--- a/karrot/pickups/tasks.py
+++ b/karrot/pickups/tasks.py
@@ -70,7 +70,7 @@ def fetch_pickup_notification_data_for_group(group):
             GroupNotificationType.DAILY_PICKUP_NOTIFICATION
         ),
     ).exclude(
-        groupmembership__user__in=User.objects.unverified_or_ignored(),
+        groupmembership__user__in=User.objects.unverified(),
     )
 
     for user in users:

--- a/karrot/userauth/tests/test_userauth_api.py
+++ b/karrot/userauth/tests/test_userauth_api.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 from anymail.exceptions import AnymailAPIError
+from anymail.signals import EventType
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib import auth
@@ -592,12 +593,14 @@ class TestFailedEmailDeliveryAPI(APITestCase, ExtractPaginationMixin):
         self.assertEqual(response.data, [])
 
     def test_get_failed_deliveries_v1(self):
-        EmailEvent.objects.create(address=self.user.email, event='bounce', payload={'reason': 'my reason'}, version=1)
+        EmailEvent.objects.create(
+            address=self.user.email, event=EventType.BOUNCED, payload={'reason': 'my reason'}, version=1
+        )
         self.client.force_login(user=self.user)
         response = self.get_results(self.url)
         self.assertEqual(response.data[0]['address'], self.user.email)
         self.assertEqual(response.data[0]['reason'], 'my reason')
-        self.assertEqual(response.data[0]['event'], 'bounce')
+        self.assertEqual(response.data[0]['event'], EventType.BOUNCED)
 
     def test_get_failed_deliveries_v2(self):
         sub_payload = {'output': 'my reason', 'message': {'subject': 'something'}}

--- a/karrot/users/models.py
+++ b/karrot/users/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.db import transaction, models
-from django.db.models import EmailField, BooleanField, TextField, CharField, DateTimeField, ForeignKey, Q
+from django.db.models import EmailField, BooleanField, TextField, CharField, DateTimeField, ForeignKey
 from django.dispatch import Signal
 from django.utils import timezone
 from versatileimagefield.fields import VersatileImageField
@@ -24,8 +24,8 @@ class UserQuerySet(models.QuerySet):
     def filter_by_similar_email(self, email):
         return self.filter(email__iexact=email)
 
-    def unverified_or_ignored(self):
-        return self.filter(Q(mail_verified=False) | Q(email__in=EmailEvent.objects.ignored_addresses()))
+    def unverified(self):
+        return self.filter(mail_verified=False)
 
     def active(self):
         return self.filter(deleted=False, is_active=True)

--- a/karrot/users/models.py
+++ b/karrot/users/models.py
@@ -223,4 +223,4 @@ class User(AbstractBaseUser, BaseModel, LocationModel):
         return self.is_superuser
 
     def failed_email_deliveries(self):
-        return EmailEvent.objects.for_user(self)
+        return EmailEvent.objects.failed_for_user(self)

--- a/karrot/users/stats.py
+++ b/karrot/users/stats.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 
 from karrot.groups.models import GroupMembership, GroupStatus
 from karrot.pickups.models import PickupDate
-from karrot.webhooks.models import EmailEvent
 
 
 def get_users_stats():
@@ -19,7 +18,6 @@ def get_users_stats():
     fields = {
         'active_count': active_users_count,
         'active_unverified_count': active_users.filter(mail_verified=False).count(),
-        'active_ignored_email_count': active_users.filter(email__in=EmailEvent.objects.ignored_addresses()).count(),
         'active_with_location_count': active_users.exclude(latitude=None).exclude(longitude=None).count(),
         'active_with_mobile_number_count': active_users.exclude(mobile_number='').count(),
         'active_with_description_count': active_users.exclude(description='').count(),

--- a/karrot/users/tests/test_stats.py
+++ b/karrot/users/tests/test_stats.py
@@ -1,7 +1,7 @@
 from dateutil.relativedelta import relativedelta
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
-from django.contrib.auth import get_user_model
 
 from karrot.groups.factories import GroupFactory
 from karrot.groups.models import GroupMembership
@@ -10,7 +10,6 @@ from karrot.pickups.models import to_range
 from karrot.places.factories import PlaceFactory
 from karrot.users import stats
 from karrot.users.factories import UserFactory, VerifiedUserFactory
-from karrot.webhooks.models import EmailEvent
 
 
 class TestUserStats(TestCase):
@@ -45,13 +44,6 @@ class TestUserStats(TestCase):
         deleted_user = UserFactory()
         deleted_user.deleted = True
         deleted_user.save()
-
-        # one user with bounced email
-        bounce_user = users[0]
-        for _ in range(5):
-            EmailEvent.objects.create(
-                created_at=timezone.now(), address=bounce_user.email, event='bounce', payload={}, version=1
-            )
 
         # one user with location
         location_user = users[1]
@@ -96,7 +88,6 @@ class TestUserStats(TestCase):
             points, {
                 'active_count': 9,
                 'active_unverified_count': 1,
-                'active_ignored_email_count': 1,
                 'active_with_location_count': 1,
                 'active_with_mobile_number_count': 1,
                 'active_with_description_count': 4,

--- a/karrot/webhooks/models.py
+++ b/karrot/webhooks/models.py
@@ -1,3 +1,4 @@
+from anymail.signals import EventType
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 
@@ -6,8 +7,8 @@ from karrot.base.base_models import BaseModel
 
 
 class EmailEventQuerySet(models.QuerySet):
-    def for_user(self, user):
-        return self.filter(address=user.email)
+    def failed_for_user(self, user):
+        return self.filter(address=user.email, event__in=[EventType.BOUNCED, EventType.FAILED, EventType.REJECTED])
 
 
 class EmailEvent(BaseModel):

--- a/karrot/webhooks/models.py
+++ b/karrot/webhooks/models.py
@@ -1,24 +1,13 @@
-from dateutil.relativedelta import relativedelta
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.db.models import Count
-from django.utils import timezone
 
 from config import settings
 from karrot.base.base_models import BaseModel
 
 
 class EmailEventQuerySet(models.QuerySet):
-    def ignored(self):
-        return self.filter(
-            created_at__gte=timezone.now() - relativedelta(months=3), event__in=settings.EMAIL_EVENTS_AVOID
-        )
-
-    def ignored_addresses(self):
-        return self.ignored().values('address').annotate(count=Count('id')).filter(count__gte=5).values('address')
-
     def for_user(self, user):
-        return self.ignored().filter(address=user.email)
+        return self.filter(address=user.email)
 
 
 class EmailEvent(BaseModel):

--- a/karrot/webhooks/tasks.py
+++ b/karrot/webhooks/tasks.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from huey import crontab
+from huey.contrib.djhuey import db_periodic_task
+
+from karrot.utils import stats_utils
+from karrot.utils.stats_utils import timer
+from karrot.webhooks.models import EmailEvent
+
+
+@db_periodic_task(crontab(hour='*/12', minute=5))  # every 12 hours
+def delete_old_email_events():
+    with timer() as t:
+        # delete email events after some months
+        EmailEvent.objects.filter(created_at__lt=timezone.now() - timedelta(days=3 * 30))
+
+    stats_utils.periodic_task('webhooks__delete_old_email_events', seconds=t.elapsed_seconds)

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 -e git+https://github.com/tiltec/talon@80886cd#egg=talon
 
 # This includes a patch to use anymail with postal
--e git+https://github.com/tiltec/django-anymail@189395d#egg=django-anymail
+-e git+https://github.com/tiltec/django-anymail@37a0ea7#egg=django-anymail
 
 # Common PyPI dependencies
 django[argon2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
--e git+https://github.com/tiltec/django-anymail@189395d#egg=django-anymail  # via -r requirements.in
+-e git+https://github.com/tiltec/django-anymail@37a0ea7#egg=django-anymail  # via -r requirements.in
 -e git+https://github.com/tiltec/django-influxdb-metrics@163730a#egg=django-influxdb-metrics  # via -r requirements.in
 -e git+https://github.com/tiltec/django-rest-swagger@d15dd9a#egg=django-rest-swagger  # via -r requirements.in
 -e git+https://github.com/tiltec/talon@80886cd#egg=talon  # via -r requirements.in


### PR DESCRIPTION
Postal handles this quite well itself, let's not duplicate the effort. That should make it easier to find out why an email didn't reach someone.

This PR removes consulting EmailEvents when sending an email to someone. If one email address has been verified once, we always try sending to this address, as long as the user is active. Postal might reject the email if it is on its suppression list. I changed the interpretation of the status webhook in `anymail` to treat supressed emails as rejected.

The user will see if an email to them was rejected (by Postal), could not be delivered (by the next mailserver) or bounced (by a mailserver further down the chain, if I understood correctly). We hopefully show enough information that the user can resolve the problem themselves, or contact us.

Before, we also showed temporary failures to the user; as this will be retried automatically and might eventually end up as a permanent failure, these temp fails are probably not useful for users.

To not keep tons of old email events in our database, I added a task to delete old ones after 3 months.