### PR TITLE
Add silk profiler to production

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,6 +117,7 @@ INSTALLED_APPS = (
     'django_jinja',
     'versatileimagefield',
     'huey.contrib.djhuey',
+    'silk',
 )
 
 REST_FRAMEWORK = {
@@ -131,6 +132,7 @@ REST_FRAMEWORK = {
 }
 
 MIDDLEWARE = (
+    'silk.middleware.SilkyMiddleware',
     'influxdb_metrics.middleware.InfluxDBRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -226,6 +228,14 @@ VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
     ]
 }
 
+# Silk profiler configuration
+# User must login
+SILKY_AUTHENTICATION = True
+# User must have is_staff = True
+SILKY_AUTHORISATION = True
+# for now, log only requests that have recording enabled
+SILKY_INTERCEPT_FUNC = lambda request: 'silky_record_requests' in request.COOKIES  # noqa: E731
+
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
@@ -295,10 +305,6 @@ HUEY = {
 # If you have the email_reply_trimmer_service running, set this to 'http://localhost:4567/trim' (or similar)
 # https://github.com/yunity/email_reply_trimmer_service
 EMAIL_REPLY_TRIMMER_URL = None
-
-if 'USE_SILK' in os.environ:
-    INSTALLED_APPS += ('silk', )
-    MIDDLEWARE = ('silk.middleware.SilkyMiddleware', ) + MIDDLEWARE
 
 # NB: Keep this as the last line, and keep
 # local_settings.py out of version control

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,7 +3,6 @@
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/2.0/topics/http/urls/
 """
-import os
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -11,18 +10,20 @@ from django.urls import path, re_path, include
 from django.views.static import serve
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
+from rest_framework_swagger.views import get_swagger_view
 
 from karrot.applications.api import ApplicationViewSet
 from karrot.community_feed.api import CommunityFeedViewSet
-from karrot.issues.api import IssuesViewSet
 from karrot.conversations.api import ConversationMessageViewSet, ConversationViewSet
 from karrot.groups.api import GroupViewSet, AgreementViewSet, GroupInfoViewSet
 from karrot.history.api import HistoryViewSet
 from karrot.invitations.api import InvitationsViewSet, InvitationAcceptViewSet
+from karrot.issues.api import IssuesViewSet
 from karrot.notifications.api import NotificationViewSet
 from karrot.offers.api import OfferViewSet
 from karrot.pickups.api import PickupDateViewSet, PickupDateSeriesViewSet, FeedbackViewSet
 from karrot.places.api import PlaceViewSet
+from karrot.stats.api import StatsView
 from karrot.status.api import StatusView
 from karrot.subscriptions.api import PushSubscriptionViewSet
 from karrot.template_previews import views as template_preview_views
@@ -31,8 +32,6 @@ from karrot.userauth.api import AuthUserView, AuthView, LogoutView, \
     RequestResetPasswordView, ChangePasswordView, VerifyMailView, ResendMailVerificationCodeView, ResetPasswordView, \
     ChangeMailView, RequestDeleteUserView, FailedEmailDeliveryView
 from karrot.users.api import UserViewSet, UserInfoViewSet
-from karrot.stats.api import StatsView
-from rest_framework_swagger.views import get_swagger_view
 
 router = DefaultRouter()
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,7 +5,6 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 """
 import os
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path, re_path, include
@@ -102,6 +101,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('docs/', get_swagger_view()),
     path('api/anymail/', include('anymail.urls')),
+    re_path(r'^silk/', include('silk.urls', namespace='silk'))
 ]
 
 if settings.DEBUG:
@@ -116,6 +116,3 @@ if settings.DEBUG:
         path('_templates', template_preview_views.list_templates),
         path('_templates/show', template_preview_views.show_template),
     ]
-
-if 'USE_SILK' in os.environ:
-    urlpatterns += [url(r'^silk/', include('silk.urls', namespace='silk'))]

--- a/karrot/management/commands/create_sample_data.py
+++ b/karrot/management/commands/create_sample_data.py
@@ -402,7 +402,9 @@ class Command(BaseCommand):
         # Create user that is already preconfigured in frontend, and join a group
         foo = User.objects.filter(email='foo@foo.com').first()
         if foo is None:
-            foo = User.objects.create_superuser(email='foo@foo.com', password='foofoo', display_name='Playground User')
+            foo = User.objects.create_user(
+                email='foo@foo.com', password='foofoo', display_name='Playground User', is_staff=True
+            )
 
         login_user(foo.id)
         join_group(groups[0]['id'])

--- a/karrot/management/commands/create_sample_data.py
+++ b/karrot/management/commands/create_sample_data.py
@@ -402,7 +402,7 @@ class Command(BaseCommand):
         # Create user that is already preconfigured in frontend, and join a group
         foo = User.objects.filter(email='foo@foo.com').first()
         if foo is None:
-            foo = User.objects.create_user(email='foo@foo.com', password='foofoo', display_name='Playground User')
+            foo = User.objects.create_superuser(email='foo@foo.com', password='foofoo', display_name='Playground User')
 
         login_user(foo.id)
         join_group(groups[0]['id'])


### PR DESCRIPTION
This will allow us to get detailed request profiling in dev and production. You need to set a cookie "silky_record_requests" (value doesn't matter) to enable it.

To see the profiles, visit `/silk`. It requires you being logged in and your user having the `is_staff` field set to 'yes'. It needs manual database editing to achieve this.

For easier local testing, we create foo@foo.com with `is_staff = True`.

Related to https://github.com/yunity/karrot-frontend/issues/1914