### PR TITLE
Fix new offer unsubscribe url

### DIFF
--- a/karrot/utils/frontend_urls.py
+++ b/karrot/utils/frontend_urls.py
@@ -85,7 +85,6 @@ def new_offer_unsubscribe_url(user, offer):
     return unsubscribe_url(
         user,
         group=offer.group,
-        conversation=offer.conversation,
         notification_type=GroupNotificationType.NEW_OFFER,
     )
 


### PR DESCRIPTION
When the offer is new you cannot be part of the conversation already, and currently it causes an error when handling the unsubscribe request.

This is the error in sentry https://sentry.io/share/issue/e3b27095fb1548ada40bda6cfc657af9/