### PR TITLE
Return timezone offsets in activity-related dates

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -12,7 +12,7 @@ from karrot.conversations.api import RetrieveConversationMixin
 from karrot.history.models import History, HistoryTypus
 from karrot.activities.filters import (ActivitiesFilter, ActivitySeriesFilter, FeedbackFilter)
 from karrot.activities.models import (
-    Activity as ActivityModel, ActivitySeries as ActivitySeriesModel, Feedback as FeedbackModel, Activity
+    Activity as ActivityModel, ActivitySeries as ActivitySeriesModel, Feedback as FeedbackModel
 )
 from karrot.activities.permissions import (
     IsUpcoming, HasNotJoinedActivity, HasJoinedActivity, IsEmptyActivity, IsNotFull, IsSameParticipant,

--- a/karrot/activities/serializers.py
+++ b/karrot/activities/serializers.py
@@ -1,5 +1,7 @@
 import dateutil.rrule
 from datetime import timedelta
+
+import pytz
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
@@ -26,14 +28,33 @@ class ActivityHistorySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class DateTimeFieldWithTimezone(DateTimeField):
+    def get_attribute(self, instance):
+        value = super().get_attribute(instance)
+        if hasattr(instance, 'timezone'):
+            return value.astimezone(instance.timezone)
+        return value
+
+    def enforce_timezone(self, value):
+        if timezone.is_aware(value):
+            return value
+        return super().enforce_timezone(value)
+
+
 class DateTimeRangeField(serializers.Field):
-    child = DateTimeField()
+    child = DateTimeFieldWithTimezone()
 
     default_error_messages = {
         'list': _('Must be a list'),
         'length': _('Must be a list with one or two values'),
         'required': _('Must pass start value'),
     }
+
+    def get_attribute(self, instance):
+        value = super().get_attribute(instance)
+        if hasattr(instance, 'timezone'):
+            return value.astimezone(instance.timezone)
+        return value
 
     def to_representation(self, value):
         return [
@@ -81,7 +102,7 @@ class ActivitySerializer(serializers.ModelSerializer):
         ]
 
     participants = serializers.SerializerMethodField()
-    feedback_due = serializers.DateTimeField(read_only=True)
+    feedback_due = DateTimeFieldWithTimezone(read_only=True)
 
     date = DateTimeRangeField()
 
@@ -265,8 +286,9 @@ class ActivitySeriesSerializer(serializers.ModelSerializer):
             'id',
         ]
 
+    start_date = DateTimeFieldWithTimezone()
     dates_preview = serializers.ListField(
-        child=serializers.DateTimeField(),
+        child=DateTimeFieldWithTimezone(),
         read_only=True,
         source='dates',
     )

--- a/karrot/activities/serializers.py
+++ b/karrot/activities/serializers.py
@@ -1,7 +1,6 @@
 import dateutil.rrule
 from datetime import timedelta
 
-import pytz
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone

--- a/karrot/base/base_models.py
+++ b/karrot/base/base_models.py
@@ -82,6 +82,12 @@ class CustomDateTimeTZRange(DateTimeTZRange):
     def as_list(self):
         return [self.start, self.end]
 
+    def astimezone(self, tz):
+        return CustomDateTimeTZRange(
+            self.lower.astimezone(tz) if self.lower else None,
+            self.upper.astimezone(tz) if self.upper else None
+        )
+
 
 class CustomDateTimeRangeField(DateTimeRangeField):
     range_type = CustomDateTimeTZRange


### PR DESCRIPTION
This implements the API part of https://github.com/yunity/karrot-frontend/issues/959.

This handles it by:
- adding `timezone` annotations to `Activity` and `ActivitySeries` querysets by default
- in the serializers overriding `get_attribute` to return dates with that timezone using `.astimezone(tz)`
- having a custom date time serializer field that actually uses the timezone in the value (the default one gets the current timezone, or a default specified when you create the field)
- fixing the anomaly for the feedback api (as the default timezone annotation for Activity model doesn't apply there...), it's a bit manual, but also keeps the number of queries the same

It doesn't feel very elegant as that is a lot of places to have to consider it, rather than being able to set it in a magic place where everything Just Works.

It might be there is a better way, like setting the timezone for the request context for the current group. Although it would still need to custom field formatters, and it would limit us to one timezone per request, which is probably a reasonable assumption at the moment, but it could make any API requests involve multiple groups complicated at some point.

In the way I did it, theoretically the timezone information could come from elsewhere should we ever want that (e.g. the places could have an override one... not that we have any groups that cross timezones currently).

For anything not activity related, I left it as it is. I think this only makes sense for things that physically happen in the group timezone.

I am assuming the frontend JustWorks at the moment, as date parsing should be fine... the dates still refers to the same point in time.