### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+- repo: local
+  hooks:
+  - id: autoflake
+    name: autoflake
+    entry: autoflake
+    args:
+    - "--in-place"
+    - "--remove-all-unused-imports"
+    language: system
+    types: [python]
+    exclude: "karrot\/.*\/migrations"
+  - id: yapf
+    name: yapf
+    entry: yapf
+    args:
+    - "--in-place"
+    language: system
+    types: [python]
+    exclude: "karrot\/.*\/migrations"
+  - id: flake8
+    name: flake8
+    entry: flake8
+    language: system
+    types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@
     args:
     - "--in-place"
     - "--remove-all-unused-imports"
+    - "--remove-unused-variables"
+    - "--remove-duplicate-keys"
+    - "--expand-star-imports"
     language: system
     types: [python]
     exclude: "karrot\/.*\/migrations"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ To get proper introspection and support from PyCharm, it's necessary to set up a
 ```
 virtualenv env
 source ./env/bin/activate
-pip install pip-tools
 ./sync.py
 ```
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -309,7 +309,7 @@ EMAIL_REPLY_TRIMMER_URL = None
 # NB: Keep this as the last line, and keep
 # local_settings.py out of version control
 try:
-    from .local_settings import *
+    from .local_settings import *  # noqa
 except ImportError:
     raise Exception(
         "config/local_settings.py is missing! Copy the provided example file and adapt it to your own config."

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -28,8 +28,7 @@ MIDDLEWARE_CLASSES = [
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache"
-    }
+    },
 }
 
 EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
-

--- a/requirements.in
+++ b/requirements.in
@@ -61,3 +61,4 @@ django-silk
 # transifex-client # disabled to prevent pulling in urllib<1.24.1
 yapf
 importlib-metadata # for py3.7 compat
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/tiltec/talon@80886cd#egg=talon  # via -r requirements.in
 aioredis==1.3.1           # via channels-redis
 apipkg==1.5               # via execnet
+appdirs==1.4.4            # via virtualenv
 argon2-cffi==20.1.0       # via django
 asgiref==3.2.10           # via channels, channels-redis, daphne, django
 async-timeout==3.0.1      # via aioredis
@@ -26,6 +27,7 @@ boltons==20.2.0           # via face, glom
 cchardet==2.1.6           # via talon
 certifi==2020.6.20        # via requests
 cffi==1.14.0              # via argon2-cffi, cryptography
+cfgv==3.1.0               # via pre-commit
 channels-redis==2.4.2     # via -r requirements.in
 channels==2.4.0           # via -r requirements.in, channels-redis
 chardet==3.0.4            # via requests, talon
@@ -38,6 +40,7 @@ cryptography==2.9.2       # via autobahn, pyopenssl, service-identity
 cssselect==1.1.0          # via talon
 daphne==2.5.0             # via -r requirements.in, channels
 decorator==4.4.2          # via ipython, traitlets
+distlib==0.3.1            # via virtualenv
 django-cors-headers==3.4.0  # via -r requirements.in
 django-crispy-forms==1.9.1  # via -r requirements.in
 django-dirtyfields==1.4   # via -r requirements.in
@@ -56,6 +59,7 @@ execnet==1.7.1            # via pytest-xdist
 face==20.1.1              # via glom
 factory-boy==2.12.0       # via -r requirements.in
 faker==4.1.1              # via factory-boy
+filelock==3.0.12          # via virtualenv
 flake8==3.8.3             # via -r requirements.in
 freezegun==0.3.15         # via -r requirements.in
 furl==2.1.0               # via -r requirements.in
@@ -68,8 +72,9 @@ html2text==2020.1.16      # via -r requirements.in
 html5lib==1.1             # via talon
 huey==2.2.0               # via -r requirements.in
 hyperlink==19.0.0         # via twisted
+identify==1.4.24          # via pre-commit
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==1.7.0  # via -r requirements.in, flake8, markdown, pluggy, pytest
+importlib-metadata==1.7.0  # via -r requirements.in
 incremental==17.5.0       # via twisted
 influxdb==5.3.0           # via django-influxdb-metrics
 ipython-genutils==0.2.0   # via traitlets
@@ -84,6 +89,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.4.0     # via -r requirements.in, pytest
 msgpack==0.6.1            # via channels-redis, influxdb
+nodeenv==1.4.0            # via pre-commit
 openapi-codec==1.3.2      # via django-rest-swagger
 orderedmultidict==1.0.1   # via furl
 packaging==20.4           # via bleach, pytest
@@ -93,6 +99,7 @@ pickleshare==0.7.5        # via ipython
 pillow==7.1.2             # via django-versatileimagefield
 pip-tools==5.2.1          # via -r requirements.in
 pluggy==0.13.1            # via pytest
+pre-commit==2.6.0         # via -r requirements.in
 prompt-toolkit==3.0.5     # via ipython
 psutil==5.7.0             # via python-server-metrics
 psycopg2-binary==2.8.5    # via -r requirements.in
@@ -119,6 +126,7 @@ python-dateutil==2.8.1    # via django-silk, faker, freezegun, influxdb
 python-magic==0.4.18      # via django-versatileimagefield
 python-server-metrics==0.2.1  # via django-influxdb-metrics
 pytz==2020.1              # via -r requirements.in, babel, django, django-dirtyfields, django-silk, django-timezone-field, influxdb
+pyyaml==5.3.1             # via pre-commit
 raven==6.10.0             # via -r requirements.in
 redis==3.5.3              # via -r requirements.in, django-redis
 regex==2020.6.8           # via talon
@@ -126,18 +134,19 @@ requests-mock==1.8.0      # via -r requirements.in
 requests==2.24.0          # via -r requirements.in, coreapi, django-anymail, django-silk, influxdb, pyfcm, requests-mock
 service-identity==18.1.0  # via twisted
 simplejson==3.17.0        # via django-rest-swagger
-six==1.15.0               # via argon2-cffi, automat, bleach, cryptography, django-anymail, django-enumfield, django-extensions, djangorestframework-csv, freezegun, furl, html5lib, influxdb, orderedmultidict, packaging, pip-tools, pyopenssl, pytest-xdist, python-dateutil, requests-mock, talon, traitlets
+six==1.15.0               # via argon2-cffi, automat, bleach, cryptography, django-anymail, django-enumfield, django-extensions, djangorestframework-csv, freezegun, furl, html5lib, influxdb, orderedmultidict, packaging, pip-tools, pyopenssl, pytest-xdist, python-dateutil, requests-mock, talon, traitlets, virtualenv
 sqlparse==0.3.1           # via django, django-silk
 tblib==1.6.0              # via -r requirements.in
 text-unidecode==1.3       # via faker
 tld==0.12.2               # via django-influxdb-metrics
-toml==0.10.1              # via autopep8
+toml==0.10.1              # via autopep8, pre-commit
 traitlets==4.3.3          # via ipython
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.9           # via requests
+virtualenv==20.0.27       # via pre-commit
 wcwidth==0.2.5            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach, html5lib
 yapf==0.30.0              # via -r requirements.in

--- a/sync.py
+++ b/sync.py
@@ -54,4 +54,7 @@ if process_mjml:
     header("Generating new templates")
     subprocess.run(['./mjml/convert'], env=environ, check=True)
 
+header("Installing pre-commit hook")
+subprocess.run(['pre-commit', 'install'], env=environ, check=True)
+
 header('All done ☺')


### PR DESCRIPTION
For making it easier to make sure the committed files comply to flake8/yapf/etc...

The hook will get installed when you run `./sync.py`

Now, when you have _staged_ changes, it'll run autoflake (remove unused imports), yapf, and flake8 on just the changed files. Nice and fast.

If any of them fails, or changes files, the whole thing will fail. I found this a bit counter intuitive to start with as I just wanted it to fix the staged files and get on with the commit. The author of the tool points out [some nuances](https://github.com/pre-commit/pre-commit/issues/532#issuecomment-299886605) were it to do that), I can accept they are reasonable (although I think [husky](https://github.com/typicode/husky) does it differently in nodejs-land).

So, if yapf reformats a staged file when you try to commit, you have to `git add` it again, before you can complete the commit.

(in part this is an alternative to https://github.com/yunity/karrot-backend/pull/1012 - as they both make the process of conforming to coding standards fast... we could still switch to black of course and incorporate it into pre-commit)