### PR TITLE
Fixup transaction handling for message images

### DIFF
--- a/karrot/offers/receivers.py
+++ b/karrot/offers/receivers.py
@@ -1,19 +1,17 @@
-from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from karrot.conversations.models import Conversation
 from karrot.offers.models import Offer
 from karrot.offers.tasks import notify_members_about_new_offer
+from karrot.utils.misc import on_transaction_commit
 
 
 @receiver(post_save, sender=Offer)
+@on_transaction_commit
 def offer_saved(sender, instance, created, **kwargs):
     if created:
         offer = instance
         conversation = Conversation.objects.get_or_create_for_target(offer)
         conversation.join(offer.user)
-
-        # offer saving is normally done in a transaction so as to include the images
-        # we only want to trigger the notification after this transaction is complete
-        transaction.on_commit(lambda: notify_members_about_new_offer(offer))
+        notify_members_about_new_offer(offer)

--- a/karrot/subscriptions/receivers.py
+++ b/karrot/subscriptions/receivers.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 from itertools import groupby
 
 from django.conf import settings
@@ -40,9 +41,11 @@ from karrot.subscriptions.models import ChannelSubscription
 from karrot.subscriptions.utils import send_in_channel, MockRequest
 from karrot.userauth.serializers import AuthUserSerializer
 from karrot.users.serializers import UserSerializer
+from karrot.utils.misc import on_transaction_commit
 
 
 @receiver(post_save, sender=ConversationMessage)
+@on_transaction_commit
 def send_messages(sender, instance, created, **kwargs):
     """When there is a message in a conversation we need to send it to any subscribed participants."""
     message = instance
@@ -110,6 +113,7 @@ def conversation_meta_saved(sender, instance, **kwargs):
 
 
 @receiver(post_save, sender=ConversationThreadParticipant)
+@on_transaction_commit
 def send_thread_update(sender, instance, created, **kwargs):
     # Update thread object for user after updating their participation
     # (important for seen_up_to and unread_message_count)
@@ -129,6 +133,7 @@ def send_thread_update(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=ConversationMessageReaction)
 @receiver(post_delete, sender=ConversationMessageReaction)
+@on_transaction_commit
 def send_reaction_update(sender, instance, **kwargs):
     reaction = instance
     message = reaction.message

--- a/karrot/utils/misc.py
+++ b/karrot/utils/misc.py
@@ -1,6 +1,14 @@
 from json import dumps as dump_json
 
+from django.db import transaction
 from rest_framework.views import exception_handler
+
+
+def on_transaction_commit(func):
+    def inner(*args, **kwargs):
+        transaction.on_commit(lambda: func(*args, **kwargs))
+
+    return inner
 
 
 def json_stringify(data):


### PR DESCRIPTION
For the offer images I had to ensure to do some of notifications using `transaction.on_commit` to ensure the images were saved and available for the receiver handlers/notifications/etc, we also need to do this for message images so. I implemented an `@thing` that simplifies it now for both cases, and made the tests TransactionTestCases where applicable.

~~... actually I might tag a few other things into this PR that relate to the message images ...~~ changed my mind