### PR TITLE
Order feedback by activity start date

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -29,7 +29,7 @@ from karrot.utils.mixins import PartialUpdateModelMixin
 
 class FeedbackPagination(CursorPagination):
     page_size = 10
-    ordering = '-id'
+    ordering = '-activity_date'
 
 
 class FeedbackViewSet(
@@ -65,7 +65,9 @@ class FeedbackViewSet(
         queryset = self.filter_queryset(self.get_queryset()) \
             .select_related('about') \
             .prefetch_related('about__activityparticipant_set', 'about__feedback_given_by') \
-            .annotate(timezone=F('about__place__group__timezone'))
+            .annotate(
+              timezone=F('about__place__group__timezone'),
+              activity_date=F('about__date__startswith'))
         feedback = self.paginate_queryset(queryset)
 
         activities = set()


### PR DESCRIPTION
Fixes https://github.com/yunity/karrot-frontend/issues/2157

The cursor pagination disallows double-underscore lookups for pagination ordering, I think because it assumes they will break the "rules" on what can be a valid ordering field, see [docs](https://www.django-rest-framework.org/api-guide/pagination/#details-and-limitations). In our case I think this should be fine still, as by the time the feedback is created the pickup cannot be changed anyway as it's in the past. I cheated the check by using an annotation...