### PR TITLE
Remove some playground exceptions

### DIFF
--- a/karrot/groups/receivers.py
+++ b/karrot/groups/receivers.py
@@ -38,15 +38,9 @@ def group_member_added(sender, instance, created, **kwargs):
         return
     group = instance.group
     user = instance.user
-    membership = instance
-
-    if group.is_playground():
-        membership.notification_types = []
-        membership.roles.append(roles.GROUP_EDITOR)
-        membership.save()
 
     conversation = Conversation.objects.get_or_create_for_target(group)
-    conversation.join(user, muted=group.is_playground())
+    conversation.join(user, muted=False)
 
     stats.group_joined(group)
 

--- a/karrot/groups/tests/test_model.py
+++ b/karrot/groups/tests/test_model.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from karrot.conversations.models import Conversation, ConversationParticipant
-from karrot.groups.factories import GroupFactory, PlaygroundGroupFactory
+from karrot.groups.factories import GroupFactory
 from karrot.groups.models import Group, get_default_notification_types
 from karrot.activities.factories import ActivityFactory
 from karrot.activities.models import to_range
@@ -33,15 +33,6 @@ class TestGroupModel(TestCase):
         conversation = Conversation.objects.get_for_target(group)
         conversation_participant = ConversationParticipant.objects.get(conversation=conversation, user=user)
         self.assertFalse(conversation_participant.muted)
-
-    def test_no_notifications_by_default_in_playground(self):
-        user = UserFactory()
-        group = PlaygroundGroupFactory()
-        membership = group.groupmembership_set.create(user=user)
-        self.assertEqual([], membership.notification_types)
-        conversation = Conversation.objects.get_for_target(group)
-        conversation_participant = ConversationParticipant.objects.get(conversation=conversation, user=user)
-        self.assertTrue(conversation_participant.muted)
 
     def test_uses_default_application_questions_if_not_specified(self):
         group = GroupFactory(application_questions='')

--- a/karrot/groups/tests/test_receivers.py
+++ b/karrot/groups/tests/test_receivers.py
@@ -1,4 +1,3 @@
-from django.core import mail
 from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
@@ -6,8 +5,8 @@ from django.test import TestCase
 from django.utils import timezone
 
 from karrot.conversations.models import Conversation, ConversationParticipant
-from karrot.groups.factories import GroupFactory, PlaygroundGroupFactory
-from karrot.groups.models import GroupMembership, Trust
+from karrot.groups.factories import GroupFactory
+from karrot.groups.models import GroupMembership
 from karrot.users.factories import UserFactory
 
 
@@ -80,27 +79,3 @@ class TestSendStatistics(TestCase):
         membership.inactive_at = None
         membership.save()
         self.assertFalse(write_mock.called)
-
-
-class TestGroupPlaygroundReceivers(TestCase):
-    def setUp(self):
-        self.group = PlaygroundGroupFactory()
-
-    def test_playground_members_are_always_editors(self):
-        new_member = UserFactory()
-        mail.outbox = []
-
-        self.group.add_member(new_member)
-
-        self.assertTrue(self.group.is_editor(new_member))
-        # no email should be sent when joining playground
-        self.assertEqual(len(mail.outbox), 0)
-
-        # no email should be sent when giving trust
-        membership = GroupMembership.objects.get(group=self.group, user=new_member)
-        another_user = UserFactory()
-        self.group.add_member(another_user)
-        mail.outbox = []
-        Trust.objects.create(membership=membership, given_by=another_user)
-
-        self.assertEqual(len(mail.outbox), 0)

--- a/karrot/management/commands/create_sample_data.py
+++ b/karrot/management/commands/create_sample_data.py
@@ -413,7 +413,6 @@ class Command(BaseCommand):
         if not Group.objects.filter(status=GroupStatus.PLAYGROUND.value).exists():
             group = Group.objects.order_by('?').first()
             group.status = GroupStatus.PLAYGROUND.value
-            group.is_open = True
             group.save()
 
         print_success('Done! You can login with any of those mail addresses and password {}'.format(default_password))

--- a/karrot/notifications/receivers.py
+++ b/karrot/notifications/receivers.py
@@ -41,9 +41,6 @@ def user_became_editor(sender, instance, **kwargs):
         },
     )
 
-    if membership.group.is_playground():
-        return
-
     for member in membership.group.members.exclude(id=membership.user_id):
         Notification.objects.create(
             type=NotificationType.USER_BECAME_EDITOR.value,

--- a/karrot/notifications/tests/test_receivers.py
+++ b/karrot/notifications/tests/test_receivers.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from karrot.applications.factories import ApplicationFactory
-from karrot.groups.factories import GroupFactory, PlaygroundGroupFactory
+from karrot.groups.factories import GroupFactory
 from karrot.groups.models import GroupMembership
 from karrot.groups.roles import GROUP_EDITOR
 from karrot.invitations.models import Invitation
@@ -45,18 +45,6 @@ class TestNotificationReceivers(TestCase):
         self.assertEqual(you_became_editor.user, user)
         user_became_editor = Notification.objects.get(type=NotificationType.USER_BECAME_EDITOR.value)
         self.assertEqual(user_became_editor.user, user1)
-
-    def test_prevent_user_became_editor_when_joining_playground(self):
-        user1 = UserFactory()
-        group = PlaygroundGroupFactory(newcomers=[user1])
-        Notification.objects.all().delete()
-
-        user = UserFactory()
-        group.add_member(user)
-
-        self.assertEqual(Notification.objects.count(), 1)
-        you_became_editor = Notification.objects.get(type=NotificationType.YOU_BECAME_EDITOR.value)
-        self.assertEqual(you_became_editor.user, user)
 
     def test_creates_new_applicant_notification(self):
         member = UserFactory()


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/pull/2175 and https://community.foodsaving.world/t/how-to-handle-the-spam-in-the-playground-group/486

- Don't make new playground group members editors by default
- Don't prevent bell notifications when playground group member became editor