### PR TITLE
Add geoip for group preview endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: karrot/python:2.3
+      - image: karrot/python:2.4
         environment:
           PGHOST: 127.0.0.1
       - image: circleci/postgres:11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: karrot/python:2.3
+    - image: karrot/python:2.4
 
 aliases:
   - &restore-env-cache

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ uploads
 
 # Mac files
 **/.DS_Store
+
+# Maxmind geoip data
+/maxmind-data/*.mmdb

--- a/config/settings.py
+++ b/config/settings.py
@@ -308,6 +308,8 @@ HUEY = {
     'immediate': True,
 }
 
+GEOIP_PATH = os.path.join(BASE_DIR, 'maxmind-data')
+
 # If you have the email_reply_trimmer_service running, set this to 'http://localhost:4567/trim' (or similar)
 # https://github.com/yunity/email_reply_trimmer_service
 EMAIL_REPLY_TRIMMER_URL = None

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -280,7 +280,7 @@ def get_client_ip(request):
         return request.META.get('REMOTE_ADDR')
 
 
-@lru_cache
+@lru_cache()
 def ip_to_lat_lon(ip):
     try:
         return geoip.lat_lon(ip)

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -1,9 +1,13 @@
 import pytz
 from django.conf import settings
+from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
+from django.contrib.gis.geos import Point
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
+from geoip2.errors import AddressNotFoundError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError, PermissionDenied
+from rest_framework.fields import Field
 from versatileimagefield.serializers import VersatileImageFieldSerializer
 
 from karrot.groups.models import Group as GroupModel, GroupMembership, Agreement, UserAgreement, \
@@ -257,6 +261,98 @@ class AgreementAgreeSerializer(serializers.ModelSerializer):
         return instance
 
 
+try:
+    geoip = GeoIP2()
+    print('geoip functionality is available')
+except GeoIP2Exception as err:
+    print('GeoIP2 error', err)
+    print('geoip functionality is not available')
+    geoip = None
+
+CURRENT_LAT_LON_SESSION_KEY = 'geoip:current_lat_lon'
+
+
+def get_client_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        return x_forwarded_for.split(',')[0]
+    else:
+        return request.META.get('REMOTE_ADDR')
+
+
+class DistanceField(Field):
+    """
+    Returns distance of the object from users current location.
+    - the object must have latitude/longitude fields
+    - the users location is detirmined via geoip if available
+    - if the user is authenticated the co-ordinates found are saved in the session.
+    - the return unit is km rounded to the nearest km
+
+    It may return None under various conditions:
+    - the GeoIP2 libary was not initialized (missing the files)
+    - there is no request context or session
+    - we cannot detirmine the IP address of the client
+    - the IP address cannot be found in the database
+    """
+    def __init__(self, **kwargs):
+        kwargs['source'] = '*'
+        kwargs['read_only'] = True
+        super().__init__(**kwargs)
+
+    def to_representation(self, value):
+        if not geoip:
+            return None
+
+        if not (hasattr(value, 'latitude') and hasattr(value, 'longitude')):
+            raise Exception('Must have latitude and longitude fields to use DistanceField')
+
+        if not value.latitude or not value.longitude:
+            return None
+
+        request = self.context.get('request', None)
+        if not request:
+            return None
+
+        is_authenticated = request.user.is_authenticated
+
+        current_lat_lon = None
+
+        if is_authenticated:
+            current_lat_lon = request.session.get(CURRENT_LAT_LON_SESSION_KEY, None)
+
+            # "False" means we already tried finding it, but failed, don't try again
+            if current_lat_lon is False:
+                return None
+
+        if current_lat_lon is None:
+            client_ip = get_client_ip(request)
+            if client_ip:
+                try:
+                    current_lat_lon = geoip.lat_lon(client_ip)
+                except AddressNotFoundError:
+                    # we use "False" to mean we looked it up but couldn't find it
+                    current_lat_lon = False
+
+            if is_authenticated:
+                # only modify session if we already have one
+                # this isn't worth creating a session for
+                request.session[CURRENT_LAT_LON_SESSION_KEY] = current_lat_lon
+
+        if not current_lat_lon:
+            return None
+
+        # use WGS84
+        # https://docs.djangoproject.com/en/3.1/ref/contrib/gis/model-api/#django.contrib.gis.db.models.BaseSpatialField.srid
+        srid = 4326
+        current_point = Point(current_lat_lon[1], current_lat_lon[0], srid=srid)
+        point = Point(value.longitude, value.latitude, srid=srid)
+
+        # I don't think this does any fancy curvature calculation, probably enough though :)
+        # not sure what unit or the * 100 is? I took it from https://gis.stackexchange.com/a/21871
+        # it seems to be km (I calculated distance using another tool to compare)
+        return round(current_point.distance(point) * 100)
+
+
 class GroupPreviewSerializer(GroupBaseSerializer):
     """
     Public information for all visitors
@@ -264,6 +360,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
     """
     application_questions = serializers.SerializerMethodField()
     photo_urls = VersatileImageFieldSerializer(sizes='group_logo', read_only=True, source='photo')
+    distance = DistanceField()
 
     class Meta:
         model = GroupModel
@@ -280,6 +377,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
             'theme',
             'is_open',
             'photo_urls',
+            'distance',
         ]
 
     def get_application_questions(self, group):

--- a/karrot/groups/tests/test_api.py
+++ b/karrot/groups/tests/test_api.py
@@ -10,7 +10,6 @@ from karrot.groups import roles
 from karrot.groups.factories import GroupFactory
 from karrot.groups.models import Group as GroupModel, GroupMembership, Agreement, UserAgreement, \
     GroupNotificationType, get_default_notification_types, Group
-from karrot.groups.serializers import CURRENT_LAT_LON_SESSION_KEY
 from karrot.groups.stats import group_tags
 from karrot.history.models import History, HistoryTypus
 from karrot.activities.factories import ActivityFactory
@@ -100,13 +99,11 @@ class TestGroupsInfoGeoIPAPI(APITestCase):
         self.assertIsNone(response.data[0]['distance'])
 
     @patch('karrot.groups.serializers.geoip')
-    def test_saves_value_in_session(self, geoip):
+    def test_caches_geoip_lookup(self, geoip):
         lat_lng = [float(val) for val in faker.latlng()]
         geoip.lat_lon.return_value = lat_lng
         self.client.force_login(user=self.user)
-        self.assertIsNone(self.client.session.get(CURRENT_LAT_LON_SESSION_KEY))
         self.client.get(self.url)
-        self.assertEqual(self.client.session[CURRENT_LAT_LON_SESSION_KEY], lat_lng)
         geoip.lat_lon.assert_called()
 
         # if we call again it should not look up the ip again

--- a/karrot/groups/tests/test_serializers.py
+++ b/karrot/groups/tests/test_serializers.py
@@ -27,6 +27,6 @@ class TestGroupSerializer(TestCase):
 
     def test_preview(self):
         serializer = GroupPreviewSerializer(self.group)
-        self.assertEqual(len(serializer.data.keys()), 12)
+        self.assertEqual(len(serializer.data.keys()), 13)
         self.assertEqual(serializer.data['id'], self.group.id)
         self.assertEqual(serializer.data['name'], self.group.name)

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -334,23 +334,23 @@ msgstr ""
 msgid "You already gave trust to this user"
 msgstr ""
 
-#: karrot/groups/serializers.py:25
+#: karrot/groups/serializers.py:29
 msgid "Unknown timezone"
 msgstr ""
 
-#: karrot/groups/serializers.py:33
+#: karrot/groups/serializers.py:37
 msgid "Playground"
 msgstr ""
 
-#: karrot/groups/serializers.py:133 karrot/groups/serializers.py:228
+#: karrot/groups/serializers.py:137 karrot/groups/serializers.py:232
 msgid "You cannot manage agreements"
 msgstr ""
 
-#: karrot/groups/serializers.py:135
+#: karrot/groups/serializers.py:139
 msgid "Agreement is not for this group"
 msgstr ""
 
-#: karrot/groups/serializers.py:226
+#: karrot/groups/serializers.py:230
 msgid "You are not in this group"
 msgstr ""
 

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -334,23 +334,23 @@ msgstr ""
 msgid "You already gave trust to this user"
 msgstr ""
 
-#: karrot/groups/serializers.py:29
+#: karrot/groups/serializers.py:31
 msgid "Unknown timezone"
 msgstr ""
 
-#: karrot/groups/serializers.py:37
+#: karrot/groups/serializers.py:39
 msgid "Playground"
 msgstr ""
 
-#: karrot/groups/serializers.py:137 karrot/groups/serializers.py:232
+#: karrot/groups/serializers.py:139 karrot/groups/serializers.py:234
 msgid "You cannot manage agreements"
 msgstr ""
 
-#: karrot/groups/serializers.py:139
+#: karrot/groups/serializers.py:141
 msgid "Agreement is not for this group"
 msgstr ""
 
-#: karrot/groups/serializers.py:230
+#: karrot/groups/serializers.py:232
 msgid "You are not in this group"
 msgstr ""
 

--- a/maxmind-data/README.md
+++ b/maxmind-data/README.md
@@ -1,0 +1,9 @@
+Optionally provide maxmind geoip data.
+
+See guide at https://docs.djangoproject.com/en/dev/ref/contrib/gis/geoip2/ for how to get it.
+
+Once you've done that you should have two extra files in here:
+- GeoLite2-Country.mmdb
+- GeoLite2-City.mmdb
+
+We have a karrot-specific account you can use for downloading the files.

--- a/requirements.in
+++ b/requirements.in
@@ -41,6 +41,7 @@ channels_redis
 more-itertools
 requests
 glom
+geoip2
 
 # dev PyPI dependencies
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,14 @@
 -e git+https://github.com/tiltec/django-influxdb-metrics@f8839571d522503870d79d72c686ca42f5326f9c#egg=django-influxdb-metrics  # via -r requirements.in
 -e git+https://github.com/tiltec/django-rest-swagger@d15dd9a#egg=django-rest-swagger  # via -r requirements.in
 -e git+https://github.com/tiltec/talon@80886cd#egg=talon  # via -r requirements.in
+aiohttp==3.6.3            # via geoip2
 aioredis==1.3.1           # via channels-redis
 apipkg==1.5               # via execnet
 appdirs==1.4.4            # via virtualenv
 argon2-cffi==20.1.0       # via django
 asgiref==3.2.10           # via channels, channels-redis, daphne, django
-async-timeout==3.0.1      # via aioredis
-attrs==20.2.0             # via automat, glom, pytest, service-identity, twisted
+async-timeout==3.0.1      # via aiohttp, aioredis
+attrs==20.2.0             # via aiohttp, automat, glom, pytest, service-identity, twisted
 autobahn==20.7.1          # via daphne
 autoflake==1.4            # via -r requirements.in
 automat==20.2.0           # via twisted
@@ -30,7 +31,7 @@ cffi==1.14.3              # via argon2-cffi, cryptography
 cfgv==3.2.0               # via pre-commit
 channels-redis==3.1.0     # via -r requirements.in
 channels==2.4.0           # via -r requirements.in, channels-redis
-chardet==3.0.4            # via requests, talon
+chardet==3.0.4            # via aiohttp, requests, talon
 click==7.1.2              # via pip-tools
 constantly==15.1.0        # via twisted
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
@@ -63,6 +64,7 @@ filelock==3.0.12          # via virtualenv
 flake8==3.8.4             # via -r requirements.in
 freezegun==1.0.0          # via -r requirements.in
 furl==2.1.0               # via -r requirements.in
+geoip2==4.1.0             # via -r requirements.in
 gevent==20.9.0            # via -r requirements.in
 glom==20.8.0              # via -r requirements.in
 gprof2dot==2019.11.30     # via django-silk
@@ -73,8 +75,8 @@ html5lib==1.1             # via talon
 huey==2.3.0               # via -r requirements.in
 hyperlink==20.0.1         # via twisted
 identify==1.5.5           # via pre-commit
-idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==2.0.0  # via -r requirements.in, flake8, markdown, pluggy, pre-commit, pytest, virtualenv
+idna==2.10                # via hyperlink, requests, twisted, yarl
+importlib-metadata==2.0.0  # via -r requirements.in
 incremental==17.5.0       # via twisted
 git+https://github.com/influxdata/influxdb-python@cc41e290f690c4eb67f75c98fa9f027bdb6eb16b#egg=influxdbtld  # via django-influxdb-metrics
 iniconfig==1.0.1          # via pytest
@@ -87,9 +89,11 @@ logging-tree==1.8.1       # via -r requirements.in
 lxml==4.5.2               # via talon
 markdown==3.2.2           # via -r requirements.in, pymdown-extensions
 markupsafe==1.1.1         # via jinja2
+maxminddb==2.0.3          # via geoip2
 mccabe==0.6.1             # via flake8
 more-itertools==8.5.0     # via -r requirements.in
 msgpack==1.0.0            # via channels-redis, influxdb
+multidict==4.7.6          # via aiohttp, yarl
 nodeenv==1.5.0            # via pre-commit
 openapi-codec==1.3.2      # via django-rest-swagger
 orderedmultidict==1.0.1   # via furl
@@ -132,7 +136,7 @@ raven==6.10.0             # via -r requirements.in
 redis==3.5.3              # via -r requirements.in, django-redis
 regex==2020.9.27          # via talon
 requests-mock==1.8.0      # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, coreapi, django-anymail, django-silk, influxdb, pyfcm, requests-mock
+requests==2.24.0          # via -r requirements.in, coreapi, django-anymail, django-silk, geoip2, influxdb, pyfcm, requests-mock
 service-identity==18.1.0  # via twisted
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via argon2-cffi, automat, bleach, cryptography, django-anymail, django-enumfield, djangorestframework-csv, furl, html5lib, influxdb, orderedmultidict, packaging, pip-tools, pyopenssl, python-dateutil, requests-mock, talon, virtualenv
@@ -145,11 +149,12 @@ twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.10          # via requests
+urllib3==1.25.10          # via geoip2, requests
 virtualenv==20.0.32       # via pre-commit
 wcwidth==0.2.5            # via prompt-toolkit
 webencodings==0.5.1       # via bleach, html5lib
 yapf==0.30.0              # via -r requirements.in
+yarl==1.5.1               # via aiohttp
 zipp==3.3.0               # via importlib-metadata
 zope.event==4.5.0         # via gevent
 zope.interface==5.1.2     # via gevent, twisted


### PR DESCRIPTION
Users get a bit confused sometimes when signing up and lose their way to the group they were trying to get to. We can make this a bit easier by showing them the groups closest to them more prominently.

It's mainly a frontend task, but in order to support that we can use geoip to calculate the distance of the groups to the user. This adds an extra "distance" field to the group preview data with the distance information in km, rounded to the nearest km.

It will work whether the user is logged in or not. If they are logged in, the lat/lng result will be saved in the session for future use.

Now I'm writing this I'm wondering if it's also useful to return the geoip value to the user too, so it can be used for centring the map, etc... (could even have calculated the distances fully in the client if so...).