### PR TITLE
Add bootstrap endpoint

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,6 +87,7 @@ INSTALLED_APPS = (
     'karrot',
     'karrot.applications.ApplicationsConfig',
     'karrot.base.BaseConfig',
+    'karrot.bootstrap.BootstrapConfig',
     'karrot.community_feed.CommunityFeedConfig',
     'karrot.issues.IssuesConfig',
     'karrot.userauth.UserAuthConfig',

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ from rest_framework.routers import DefaultRouter
 from rest_framework_swagger.views import get_swagger_view
 
 from karrot.applications.api import ApplicationViewSet
+from karrot.bootstrap.api import BootstrapViewSet
 from karrot.community_feed.api import CommunityFeedViewSet
 from karrot.conversations.api import ConversationMessageViewSet, ConversationViewSet
 from karrot.groups.api import GroupViewSet, AgreementViewSet, GroupInfoViewSet
@@ -34,6 +35,8 @@ from karrot.userauth.api import AuthUserView, AuthView, LogoutView, \
 from karrot.users.api import UserViewSet, UserInfoViewSet
 
 router = DefaultRouter()
+
+router.register('bootstrap', BootstrapViewSet, basename='bootstrap')
 
 router.register('groups', GroupViewSet)
 router.register('groups-info', GroupInfoViewSet, basename='groupinfo')

--- a/karrot/bootstrap/__init__.py
+++ b/karrot/bootstrap/__init__.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class BootstrapConfig(AppConfig):
+    name = 'karrot.bootstrap'

--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -1,25 +1,9 @@
-from dataclasses import dataclass
-from typing import Optional
-
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from karrot.bootstrap.serializers import BootstrapSerializer
 from karrot.groups.models import Group
 from karrot.utils.geoip import get_client_ip, ip_to_lat_lon, geoip_is_available
-
-
-@dataclass
-class BootstrapData:
-    user: Optional[dict]
-    geoip: Optional[dict]
-    groups: Optional[list]
-
-
-@dataclass
-class GeoData:
-    lat: float
-    lng: float
 
 
 class BootstrapViewSet(GenericViewSet):
@@ -32,13 +16,13 @@ class BootstrapViewSet(GenericViewSet):
             if client_ip:
                 lat_lng = ip_to_lat_lon(client_ip)
                 if lat_lng:
-                    geo_data = GeoData(*lat_lng)
+                    geo_data = {'lat': lat_lng[0], 'lng': lat_lng[1]}
 
-        data = BootstrapData(
-            user=user if user.is_authenticated else None,
-            geoip=geo_data,
-            groups=Group.objects.prefetch_related('members'),
-        )
+        data = {
+            'user': user if user.is_authenticated else None,
+            'geoip': geo_data,
+            'groups': Group.objects.prefetch_related('members'),
+        }
 
         serializer = BootstrapSerializer(data, context=self.get_serializer_context())
         return Response(serializer.data)

--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -6,7 +6,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from karrot.bootstrap.serializers import BootstrapSerializer
 from karrot.groups.models import Group
-from karrot.utils.geoip import get_client_ip, ip_to_lat_lon
+from karrot.utils.geoip import get_client_ip, ip_to_lat_lon, geoip_is_available
 
 
 @dataclass
@@ -27,11 +27,12 @@ class BootstrapViewSet(GenericViewSet):
         user = request.user
         geo_data = None
 
-        client_ip = get_client_ip(request)
-        if client_ip:
-            lat_lng = ip_to_lat_lon(client_ip)
-            if lat_lng:
-                geo_data = GeoData(*lat_lng)
+        if geoip_is_available():
+            client_ip = get_client_ip(request)
+            if client_ip:
+                lat_lng = ip_to_lat_lon(client_ip)
+                if lat_lng:
+                    geo_data = GeoData(*lat_lng)
 
         data = BootstrapData(
             user=user if user.is_authenticated else None,

--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -1,24 +1,19 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from django.contrib.auth import get_user_model
-from django.db.models import Q
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from karrot.bootstrap.serializers import BootstrapSerializer
 from karrot.groups.models import Group
-from karrot.status.helpers import status_data
 from karrot.utils.geoip import get_client_ip, ip_to_lat_lon
 
 
 @dataclass
 class BootstrapData:
-    auth_user: Optional[dict]
-    groups_info: Optional[list]
+    user: Optional[dict]
     geoip: Optional[dict]
-    status: Optional[dict]
-    users: Optional[list]
+    groups: Optional[list]
 
 
 @dataclass
@@ -30,34 +25,19 @@ class GeoData:
 class BootstrapViewSet(GenericViewSet):
     def list(self, request, *args, **kwargs):
         user = request.user
-        geo = None
-
-        if user.is_authenticated:
-            status = status_data(user)
-
-            is_member_of_group = Q(groups__in=user.groups.all())
-            is_self = Q(id=user.id)
-            groups = user.groups.all()
-            is_applicant_of_group = Q(application__group__in=groups)
-            users = get_user_model().objects.active().filter(is_member_of_group | is_applicant_of_group |
-                                                             is_self).distinct()
-        else:
-            status = None
-            users = None
+        geo_data = None
 
         client_ip = get_client_ip(request)
-        client_ip = '47.68.119.255'
         if client_ip:
             lat_lng = ip_to_lat_lon(client_ip)
             if lat_lng:
-                geo = GeoData(*lat_lng)
+                geo_data = GeoData(*lat_lng)
 
         data = BootstrapData(
-            auth_user=user if user.is_authenticated else None,
-            groups_info=Group.objects.prefetch_related('members'),
-            geoip=geo,
-            status=status,
-            users=users,
+            user=user if user.is_authenticated else None,
+            geoip=geo_data,
+            groups=Group.objects.prefetch_related('members'),
         )
+
         serializer = BootstrapSerializer(data, context=self.get_serializer_context())
         return Response(serializer.data)

--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from karrot.bootstrap.serializers import BootstrapSerializer
+from karrot.groups.models import Group
+from karrot.status.helpers import status_data
+from karrot.utils.geoip import get_client_ip, ip_to_lat_lon
+
+
+@dataclass
+class BootstrapData:
+    auth_user: Optional[dict]
+    groups_info: Optional[list]
+    geoip: Optional[dict]
+    status: Optional[dict]
+    users: Optional[list]
+
+
+@dataclass
+class GeoData:
+    lat: float
+    lng: float
+
+
+class BootstrapViewSet(GenericViewSet):
+    def list(self, request, *args, **kwargs):
+        user = request.user
+        geo = None
+
+        if user.is_authenticated:
+            status = status_data(user)
+
+            is_member_of_group = Q(groups__in=user.groups.all())
+            is_self = Q(id=user.id)
+            groups = user.groups.all()
+            is_applicant_of_group = Q(application__group__in=groups)
+            users = get_user_model().objects.active().filter(is_member_of_group | is_applicant_of_group |
+                                                             is_self).distinct()
+        else:
+            status = None
+            users = None
+
+        client_ip = get_client_ip(request)
+        client_ip = '47.68.119.255'
+        if client_ip:
+            lat_lng = ip_to_lat_lon(client_ip)
+            if lat_lng:
+                geo = GeoData(*lat_lng)
+
+        data = BootstrapData(
+            auth_user=user if user.is_authenticated else None,
+            groups_info=Group.objects.prefetch_related('members'),
+            geoip=geo,
+            status=status,
+            users=users,
+        )
+        serializer = BootstrapSerializer(data, context=self.get_serializer_context())
+        return Response(serializer.data)

--- a/karrot/bootstrap/serializers.py
+++ b/karrot/bootstrap/serializers.py
@@ -1,9 +1,7 @@
 from rest_framework import serializers
 
 from karrot.groups.serializers import GroupPreviewSerializer
-from karrot.status.helpers import StatusSerializer
 from karrot.userauth.serializers import AuthUserSerializer
-from karrot.users.serializers import UserSerializer
 
 
 class GeoSerializer(serializers.Serializer):
@@ -12,8 +10,6 @@ class GeoSerializer(serializers.Serializer):
 
 
 class BootstrapSerializer(serializers.Serializer):
-    auth_user = AuthUserSerializer()
+    user = AuthUserSerializer()
     geoip = GeoSerializer()
-    users = UserSerializer(many=True)
-    status = StatusSerializer()
-    groups_info = GroupPreviewSerializer(many=True)
+    groups = GroupPreviewSerializer(many=True)

--- a/karrot/bootstrap/serializers.py
+++ b/karrot/bootstrap/serializers.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from karrot.groups.serializers import GroupPreviewSerializer
+from karrot.status.helpers import StatusSerializer
+from karrot.userauth.serializers import AuthUserSerializer
+from karrot.users.serializers import UserSerializer
+
+
+class GeoSerializer(serializers.Serializer):
+    lat = serializers.FloatField()
+    lng = serializers.FloatField()
+
+
+class BootstrapSerializer(serializers.Serializer):
+    auth_user = AuthUserSerializer()
+    geoip = GeoSerializer()
+    users = UserSerializer(many=True)
+    status = StatusSerializer()
+    groups_info = GroupPreviewSerializer(many=True)

--- a/karrot/bootstrap/tests/test_api.py
+++ b/karrot/bootstrap/tests/test_api.py
@@ -1,0 +1,38 @@
+from unittest.mock import ANY, patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from karrot.groups.factories import GroupFactory
+from karrot.users.factories import UserFactory
+from karrot.utils.tests.fake import faker
+
+
+class TestBootstrapAPI(APITestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.member = UserFactory()
+        self.group = GroupFactory(members=[self.member], application_questions='')
+        self.url = '/api/bootstrap/'
+        self.client_ip = '2003:d9:ef08:4a00:4b7a:7964:8a3c:a33e'
+
+    def test_as_anon(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['user'], None)
+        self.assertEqual(response.data['geoip'], None)
+        self.assertEqual(response.data['groups'], ANY)
+
+    @patch('karrot.utils.geoip.geoip')
+    def test_with_geoip(self, geoip):
+        lat_lng = [float(val) for val in faker.latlng()]
+        geoip.lat_lon.return_value = lat_lng
+        response = self.client.get(self.url, HTTP_X_FORWARDED_FOR=self.client_ip)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['geoip'], {'lat': lat_lng[0], 'lng': lat_lng[1]})
+
+    def test_when_logged_in(self):
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['user']['id'], self.user.id)

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -16,7 +16,7 @@ from karrot.activities.models import ActivityType
 from karrot.utils.misc import find_changed
 from karrot.utils.validators import prevent_reserved_names
 from . import roles
-from karrot.utils.geoip import geoip, get_client_ip, ip_to_lat_lon
+from karrot.utils.geoip import geoip_is_available, get_client_ip, ip_to_lat_lon
 
 
 class TimezoneField(serializers.Field):
@@ -286,7 +286,7 @@ class DistanceField(Field):
         super().__init__(**kwargs)
 
     def to_representation(self, value):
-        if not geoip:
+        if not geoip_is_available():
             return None
 
         if not (hasattr(value, 'latitude') and hasattr(value, 'longitude')):

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -359,7 +359,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
 
     def get_is_member(self, group):
         user = self.context['request'].user if 'request' in self.context else None
-        return group.is_member(user) if user else False
+        return user in group.members.all() if user else False
 
 
 class GroupJoinSerializer(GroupBaseSerializer):

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -328,6 +328,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
     application_questions = serializers.SerializerMethodField()
     photo_urls = VersatileImageFieldSerializer(sizes='group_logo', read_only=True, source='photo')
     distance = DistanceField()
+    member_count = serializers.SerializerMethodField()
 
     class Meta:
         model = GroupModel
@@ -340,6 +341,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
             'latitude',
             'longitude',
             'members',
+            'member_count',
             'status',
             'theme',
             'is_open',
@@ -349,6 +351,9 @@ class GroupPreviewSerializer(GroupBaseSerializer):
 
     def get_application_questions(self, group):
         return group.get_application_questions_or_default()
+
+    def get_member_count(self, group):
+        return group.members.count()
 
 
 class GroupJoinSerializer(GroupBaseSerializer):

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -329,6 +329,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
     photo_urls = VersatileImageFieldSerializer(sizes='group_logo', read_only=True, source='photo')
     distance = DistanceField()
     member_count = serializers.SerializerMethodField()
+    is_member = serializers.SerializerMethodField()
 
     class Meta:
         model = GroupModel
@@ -342,6 +343,7 @@ class GroupPreviewSerializer(GroupBaseSerializer):
             'longitude',
             'members',
             'member_count',
+            'is_member',
             'status',
             'theme',
             'is_open',
@@ -354,6 +356,10 @@ class GroupPreviewSerializer(GroupBaseSerializer):
 
     def get_member_count(self, group):
         return group.members.count()
+
+    def get_is_member(self, group):
+        user = self.context['request'].user if 'request' in self.context else None
+        return group.is_member(user) if user else False
 
 
 class GroupJoinSerializer(GroupBaseSerializer):

--- a/karrot/groups/tests/test_api.py
+++ b/karrot/groups/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+from random import randint
 from unittest.mock import patch, call
 
 from dateutil.relativedelta import relativedelta
@@ -69,6 +70,14 @@ class TestGroupsInfoAPI(APITestCase):
         group = GroupFactory(members=[self.member])
         response = self.client.get('/api/groups-info/{}/photo/'.format(group.id))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_not_too_many_queries(self):
+        # add a few more users and groups to make it clearer to see if we have an n+1 scenario
+        for _ in range(randint(3, 5)):
+            GroupFactory().add_member(UserFactory())
+        self.client.force_login(user=self.user)
+        with self.assertNumQueries(3):
+            self.client.get(self.url)
 
 
 class TestGroupsInfoGeoIPAPI(APITestCase):

--- a/karrot/groups/tests/test_api.py
+++ b/karrot/groups/tests/test_api.py
@@ -77,7 +77,7 @@ class TestGroupsInfoGeoIPAPI(APITestCase):
         self.url = '/api/groups-info/'
         self.client_ip = '2003:d9:ef08:4a00:4b7a:7964:8a3c:a33e'
 
-    @patch('karrot.groups.serializers.geoip')
+    @patch('karrot.utils.geoip.geoip')
     def test_returns_distance_via_geoip(self, geoip):
         geoip.lat_lon.return_value = [float(val) for val in faker.latlng()]
         response = self.client.get(self.url, HTTP_X_FORWARDED_FOR=self.client_ip)
@@ -85,20 +85,20 @@ class TestGroupsInfoGeoIPAPI(APITestCase):
         geoip.lat_lon.assert_called_with(self.client_ip)
         self.assertIsNotNone(response.data[0]['distance'])
 
-    @patch('karrot.groups.serializers.geoip')
+    @patch('karrot.utils.geoip.geoip')
     def test_returns_none_if_no_ip_address_provided(self, geoip):
         geoip.lat_lon.return_value = [float(val) for val in faker.latlng()]
         response = self.client.get(self.url, HTTP_X_FORWARDED_FOR=None, REMOTE_ADDR=None)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data[0]['distance'])
 
-    @patch('karrot.groups.serializers.geoip', None)
+    @patch('karrot.utils.geoip.geoip', None)
     def test_returns_none_if_geoip_not_available(self):
         response = self.client.get(self.url, HTTP_X_FORWARDED_FOR=self.client_ip)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data[0]['distance'])
 
-    @patch('karrot.groups.serializers.geoip')
+    @patch('karrot.utils.geoip.geoip')
     def test_caches_geoip_lookup(self, geoip):
         lat_lng = [float(val) for val in faker.latlng()]
         geoip.lat_lon.return_value = lat_lng

--- a/karrot/groups/tests/test_api.py
+++ b/karrot/groups/tests/test_api.py
@@ -41,18 +41,21 @@ class TestGroupsInfoAPI(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Hey there', response.data['application_questions'])
+        self.assertEqual(response.data['member_count'], 1)
 
     def test_retrieve_group_as_user(self):
         self.client.force_login(user=self.user)
         url = self.url + str(self.group.id) + '/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['is_member'], False)
 
     def test_retrieve_group_as_member(self):
         self.client.force_login(user=self.member)
         url = self.url + str(self.group.id) + '/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['is_member'], True)
 
     def test_group_image_redirect(self):
         # NOT logged in (as it needs to work in emails)

--- a/karrot/groups/tests/test_serializers.py
+++ b/karrot/groups/tests/test_serializers.py
@@ -27,6 +27,6 @@ class TestGroupSerializer(TestCase):
 
     def test_preview(self):
         serializer = GroupPreviewSerializer(self.group)
-        self.assertEqual(len(serializer.data.keys()), 14)
+        self.assertEqual(len(serializer.data.keys()), 15)
         self.assertEqual(serializer.data['id'], self.group.id)
         self.assertEqual(serializer.data['name'], self.group.name)

--- a/karrot/groups/tests/test_serializers.py
+++ b/karrot/groups/tests/test_serializers.py
@@ -27,6 +27,6 @@ class TestGroupSerializer(TestCase):
 
     def test_preview(self):
         serializer = GroupPreviewSerializer(self.group)
-        self.assertEqual(len(serializer.data.keys()), 13)
+        self.assertEqual(len(serializer.data.keys()), 14)
         self.assertEqual(serializer.data['id'], self.group.id)
         self.assertEqual(serializer.data['name'], self.group.name)

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -297,23 +297,23 @@ msgstr ""
 msgid "You already gave trust to this user"
 msgstr ""
 
-#: karrot/groups/serializers.py:33
+#: karrot/groups/serializers.py:30
 msgid "Unknown timezone"
 msgstr ""
 
-#: karrot/groups/serializers.py:41
+#: karrot/groups/serializers.py:38
 msgid "Playground"
 msgstr ""
 
-#: karrot/groups/serializers.py:141 karrot/groups/serializers.py:240
+#: karrot/groups/serializers.py:138 karrot/groups/serializers.py:237
 msgid "You cannot manage agreements"
 msgstr ""
 
-#: karrot/groups/serializers.py:143
+#: karrot/groups/serializers.py:140
 msgid "Agreement is not for this group"
 msgstr ""
 
-#: karrot/groups/serializers.py:238
+#: karrot/groups/serializers.py:235
 msgid "You are not in this group"
 msgstr ""
 

--- a/karrot/management/commands/create_sample_data.py
+++ b/karrot/management/commands/create_sample_data.py
@@ -91,15 +91,16 @@ class Command(BaseCommand):
             print('created user:', user['email'])
             return user
 
-        def make_group():
+        def make_group(country_code='DE'):
+            lat, lng, city, country, timezone = faker.local_latlng(country_code=country_code)
             response = c.post(
                 '/api/groups/', {
-                    'name': 'Group ' + faker.city(),
+                    'name': 'Group ' + city,
                     'description': faker.text(),
                     'timezone': 'Europe/Berlin',
-                    'address': faker.street_address(),
-                    'latitude': faker.latitude(),
-                    'longitude': faker.longitude()
+                    'address': faker.street_address() + ', ' + city,
+                    'latitude': lat,
+                    'longitude': lng
                 }
             )
             if response.status_code != 201:

--- a/karrot/status/api.py
+++ b/karrot/status/api.py
@@ -1,11 +1,9 @@
-from collections import defaultdict
-
 from rest_framework import views, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from karrot.status.helpers import unseen_notification_count, \
-    unread_conversations, pending_applications, get_feedback_possible
+from karrot.status.helpers import status_data, \
+    StatusSerializer
 
 
 class StatusView(views.APIView):
@@ -13,35 +11,4 @@ class StatusView(views.APIView):
 
     @staticmethod
     def get(request, **kwargs):
-        conversations = unread_conversations(request.user)
-        applications = pending_applications(request.user)
-        feedback_possible = get_feedback_possible(request.user)
-
-        groups = defaultdict(dict)
-        for group_id, conversation_data in conversations['groups'].items():
-            groups[group_id] = {
-                **conversation_data,
-            }
-
-        for group_id, application_count in applications:
-            groups[group_id]['pending_application_count'] = application_count
-
-        for group_id, feedback_possible_count in feedback_possible:
-            groups[group_id]['feedback_possible_count'] = feedback_possible_count
-
-        places = {}
-        for place_id, conversation_data in conversations['places'].items():
-            places[place_id] = {
-                **conversation_data,
-            }
-
-        data = {
-            'unseen_conversation_count': conversations['unseen_conversation_count'],
-            'unseen_thread_count': conversations['unseen_thread_count'],
-            'has_unread_conversations_or_threads': conversations['has_unread_conversations_or_threads'],
-            'unseen_notification_count': unseen_notification_count(request.user),
-            'groups': groups,
-            'places': places,
-        }
-
-        return Response(data=data, status=status.HTTP_200_OK)
+        return Response(data=StatusSerializer(status_data(request.user)).data, status=status.HTTP_200_OK)

--- a/karrot/utils/geoip.py
+++ b/karrot/utils/geoip.py
@@ -1,0 +1,29 @@
+from functools import lru_cache
+
+from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
+from geoip2.errors import AddressNotFoundError
+
+try:
+    geoip = GeoIP2()
+    print('geoip functionality is available')
+except GeoIP2Exception as err:
+    print('GeoIP2 error', err)
+    print('geoip functionality is not available')
+    geoip = None
+
+
+def get_client_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        return x_forwarded_for.split(',')[0]
+    else:
+        return request.META.get('REMOTE_ADDR')
+
+
+@lru_cache()
+def ip_to_lat_lon(ip):
+    try:
+        return geoip.lat_lon(ip)
+    except AddressNotFoundError:
+        # we use "False" to mean we looked it up but couldn't find it
+        return False

--- a/karrot/utils/geoip.py
+++ b/karrot/utils/geoip.py
@@ -12,6 +12,10 @@ except GeoIP2Exception as err:
     geoip = None
 
 
+def geoip_is_available():
+    return geoip is not None
+
+
 def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:
@@ -22,6 +26,8 @@ def get_client_ip(request):
 
 @lru_cache()
 def ip_to_lat_lon(ip):
+    if not geoip_is_available():
+        return None
     try:
         return geoip.lat_lon(ip)
     except AddressNotFoundError:


### PR DESCRIPTION
Adding a `/api/bootstrap/` to return some useful initial data for the frontend, geoip, auth user, and public groups info. Used by https://github.com/yunity/karrot-frontend/pull/2212.

It also randomly refactors status endpoint to use StatusSerializer, as I did play with a version that included status data, but reverted that bit, but thought might as well keep the StatusSerializer...

Also randomly adds a `member_count` field to the group previous, so we can eventually remove the member list...