### PR TITLE
Add oauth provider

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -120,6 +120,7 @@ INSTALLED_APPS = (
     'versatileimagefield',
     'huey.contrib.djhuey',
     'silk',
+    'oauth2_provider',
 )
 
 REST_FRAMEWORK = {
@@ -315,6 +316,11 @@ GEOIP_PATH = os.path.join(BASE_DIR, 'maxmind-data')
 # If you have the email_reply_trimmer_service running, set this to 'http://localhost:4567/trim' (or similar)
 # https://github.com/yunity/email_reply_trimmer_service
 EMAIL_REPLY_TRIMMER_URL = None
+
+OAUTH2_PROVIDER = {
+    # this is the list of available scopes
+    'SCOPES': {'karrot': 'main scope'}  # this description will/might appear in the login UI for the user
+}
 
 # NB: Keep this as the last line, and keep
 # local_settings.py out of version control

--- a/config/urls.py
+++ b/config/urls.py
@@ -107,7 +107,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('docs/', get_swagger_view()),
     path('api/anymail/', include('anymail.urls')),
-    re_path(r'^silk/', include('silk.urls', namespace='silk'))
+    re_path(r'^silk/', include('silk.urls', namespace='silk')),
+    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]
 
 if settings.DEBUG:

--- a/requirements.in
+++ b/requirements.in
@@ -42,6 +42,7 @@ more-itertools
 requests
 glom
 geoip2
+django-oauth-toolkit
 
 # dev PyPI dependencies
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,11 +49,12 @@ django-enumfield==2.0.2   # via -r requirements.in
 django-extensions==3.0.9  # via -r requirements.in
 django-filter==2.4.0      # via -r requirements.in
 django-jinja==2.7.0       # via -r requirements.in
+django-oauth-toolkit==1.3.3  # via -r requirements.in
 django-redis==4.12.1      # via -r requirements.in
 django-silk==4.1.0        # via -r requirements.in
 django-timezone-field==4.0  # via -r requirements.in
 django-versatileimagefield==2.0  # via -r requirements.in
-django[argon2]==3.1.3     # via -r requirements.in, channels, django-anymail, django-cors-headers, django-dirtyfields, django-filter, django-influxdb-metrics, django-jinja, django-redis, django-rest-swagger, django-silk, django-timezone-field, djangorestframework
+django[argon2]==3.1.3     # via -r requirements.in, channels, django-anymail, django-cors-headers, django-dirtyfields, django-filter, django-influxdb-metrics, django-jinja, django-oauth-toolkit, django-redis, django-rest-swagger, django-silk, django-timezone-field, djangorestframework
 djangorestframework-csv==2.1.0  # via -r requirements.in
 djangorestframework==3.12.2  # via -r requirements.in, django-rest-swagger, djangorestframework-csv
 execnet==1.7.1            # via pytest-xdist
@@ -76,7 +77,7 @@ huey==2.3.0               # via -r requirements.in
 hyperlink==20.0.1         # via twisted
 identify==1.5.9           # via pre-commit
 idna==2.10                # via hyperlink, requests, twisted, yarl
-importlib-metadata==2.0.0  # via -r requirements.in, flake8, markdown, pluggy, pre-commit, pytest, virtualenv
+importlib-metadata==2.0.0  # via -r requirements.in
 incremental==17.5.0       # via twisted
 git+https://github.com/influxdata/influxdb-python@cc41e290f690c4eb67f75c98fa9f027bdb6eb16b#egg=influxdbtld  # via django-influxdb-metrics
 iniconfig==1.1.1          # via pytest
@@ -95,6 +96,7 @@ more-itertools==8.6.0     # via -r requirements.in
 msgpack==1.0.0            # via channels-redis, influxdb
 multidict==5.0.0          # via aiohttp, yarl
 nodeenv==1.5.0            # via pre-commit
+oauthlib==3.1.0           # via django-oauth-toolkit
 openapi-codec==1.3.2      # via django-rest-swagger
 orderedmultidict==1.0.1   # via furl
 packaging==20.4           # via bleach, pytest
@@ -136,7 +138,7 @@ raven==6.10.0             # via -r requirements.in
 redis==3.5.3              # via -r requirements.in, django-redis
 regex==2020.10.28         # via talon
 requests-mock==1.8.0      # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, coreapi, django-anymail, django-silk, geoip2, influxdb, pyfcm, requests-mock
+requests==2.24.0          # via -r requirements.in, coreapi, django-anymail, django-oauth-toolkit, django-silk, geoip2, influxdb, pyfcm, requests-mock
 service-identity==18.1.0  # via twisted
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via argon2-cffi, automat, bleach, cryptography, django-enumfield, djangorestframework-csv, furl, html5lib, influxdb, orderedmultidict, packaging, pip-tools, pyopenssl, python-dateutil, requests-mock, talon, virtualenv
@@ -147,7 +149,7 @@ toml==0.10.2              # via autopep8, pre-commit, pytest
 traitlets==5.0.5          # via ipython
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
-typing-extensions==3.7.4.3  # via aiohttp, yarl
+typing-extensions==3.7.4.3  # via aiohttp
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.11          # via geoip2, requests


### PR DESCRIPTION
Just initial investigation into making karrot an oauth provider.

The use case is to allow people to sign into https://community.foodsaving.world and https://chat.foodsaving.world using a karrot account to make it easier for people to participate in meta topics relating to karrot development.

Further down the line it can enable more direct integration of this other content into the karrot interface, e.g. prompting participation in polls, without people having to make another account.