### PR TITLE
HINT: exclude in setup.py works on a per-package basis, not per-file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ setup(
     author_email='info@karrot.world',
     license='AGPL',
     packages=find_packages(
-        include=['config', 'karrot', 'karrot.*']
+        include=['config', 'karrot', 'karrot.*'],
     ),
     package_data={
         'config': ['options.env'],
         'karrot': ['*/templates/*.jinja2', 'COMMIT'],
     },
     include_package_data=True,
+    exclude_package_data={"config": ["local_settings"]},
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     author_email='info@karrot.world',
     license='AGPL',
     packages=find_packages(
-        include=['config', 'karrot', 'karrot.*'],
-        exclude=['config/local_settings'],  # doesn't work :(
+        include=['config', 'karrot', 'karrot.*']
     ),
     package_data={
         'config': ['options.env'],


### PR DESCRIPTION
```
        exclude=['config/local_settings'],  # doesn't work :(
```

it is not working because config/local_settings is not a package but a *file* in a package; if it were a subpackage in config, then ``config.local_settings`` would work.
See: https://github.com/pypa/setuptools/blob/a4dbe3457d89cf67ee3aa571fdb149e6eb544e88/setuptools/__init__.py#L89
I would suggest to include a generic config.local-settings file when the package is built (isn't that the case anyway?) and the package should not be built on a local (dev) machine anyways, right?

To have the intended effect i added the exclusion of the data file for the config package, see the second commit or https://setuptools.readthedocs.io/en/latest/userguide/datafiles.html (I didn't test this).