### PR TITLE
Add country code and timezone to geo ip info

### DIFF
--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -3,7 +3,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from karrot.bootstrap.serializers import BootstrapSerializer
 from karrot.groups.models import Group
-from karrot.utils.geoip import get_client_ip, ip_to_lat_lon, geoip_is_available
+from karrot.utils.geoip import geoip_is_available, get_client_ip, ip_to_city
 
 
 class BootstrapViewSet(GenericViewSet):
@@ -14,9 +14,14 @@ class BootstrapViewSet(GenericViewSet):
         if geoip_is_available():
             client_ip = get_client_ip(request)
             if client_ip:
-                lat_lng = ip_to_lat_lon(client_ip)
-                if lat_lng:
-                    geo_data = {'lat': lat_lng[0], 'lng': lat_lng[1]}
+                city = ip_to_city(client_ip)
+                if city:
+                    geo_data = {
+                        'lat': city.get('latitude', None),
+                        'lng': city.get('longitude', None),
+                        'country_code': city.get('country_code', None),
+                        'timezone': city.get('time_zone', None),
+                    }
 
         data = {
             'user': user if user.is_authenticated else None,

--- a/karrot/bootstrap/serializers.py
+++ b/karrot/bootstrap/serializers.py
@@ -7,6 +7,8 @@ from karrot.userauth.serializers import AuthUserSerializer
 class GeoSerializer(serializers.Serializer):
     lat = serializers.FloatField()
     lng = serializers.FloatField()
+    country_code = serializers.CharField()
+    timezone = serializers.CharField()
 
 
 class BootstrapSerializer(serializers.Serializer):

--- a/karrot/bootstrap/tests/test_api.py
+++ b/karrot/bootstrap/tests/test_api.py
@@ -26,10 +26,18 @@ class TestBootstrapAPI(APITestCase):
     @patch('karrot.utils.geoip.geoip')
     def test_with_geoip(self, geoip):
         lat_lng = [float(val) for val in faker.latlng()]
-        geoip.lat_lon.return_value = lat_lng
+        city = {'latitude': lat_lng[0], 'longitude': lat_lng[1], 'country_code': 'AA', 'time_zone': 'Europe/Berlin'}
+        geoip.city.return_value = city
         response = self.client.get(self.url, HTTP_X_FORWARDED_FOR=self.client_ip)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['geoip'], {'lat': lat_lng[0], 'lng': lat_lng[1]})
+        self.assertEqual(
+            dict(response.data['geoip']), {
+                'lat': city['latitude'],
+                'lng': city['longitude'],
+                'country_code': city['country_code'],
+                'timezone': city['time_zone'],
+            }
+        )
 
     def test_when_logged_in(self):
         self.client.force_login(user=self.user)

--- a/karrot/bootstrap/tests/test_api.py
+++ b/karrot/bootstrap/tests/test_api.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 
 from karrot.groups.factories import GroupFactory
 from karrot.users.factories import UserFactory
+from karrot.utils.geoip import ip_to_city
 from karrot.utils.tests.fake import faker
 
 
@@ -16,6 +17,7 @@ class TestBootstrapAPI(APITestCase):
         self.group = GroupFactory(members=[self.member], application_questions='')
         self.url = '/api/bootstrap/'
         self.client_ip = '2003:d9:ef08:4a00:4b7a:7964:8a3c:a33e'
+        ip_to_city.cache_clear()  # prevent getting cached mock values
 
     def test_as_anon(self):
         response = self.client.get(self.url)

--- a/karrot/utils/geoip.py
+++ b/karrot/utils/geoip.py
@@ -31,8 +31,7 @@ def ip_to_city(ip):
     try:
         return geoip.city(ip)
     except AddressNotFoundError:
-        # we use "False" to mean we looked it up but couldn't find it
-        return False
+        return None
 
 
 @lru_cache()
@@ -42,5 +41,4 @@ def ip_to_lat_lon(ip):
     try:
         return geoip.lat_lon(ip)
     except AddressNotFoundError:
-        # we use "False" to mean we looked it up but couldn't find it
-        return False
+        return None

--- a/karrot/utils/geoip.py
+++ b/karrot/utils/geoip.py
@@ -25,6 +25,17 @@ def get_client_ip(request):
 
 
 @lru_cache()
+def ip_to_city(ip):
+    if not geoip_is_available():
+        return None
+    try:
+        return geoip.city(ip)
+    except AddressNotFoundError:
+        # we use "False" to mean we looked it up but couldn't find it
+        return False
+
+
+@lru_cache()
 def ip_to_lat_lon(ip):
     if not geoip_is_available():
         return None

--- a/karrot/utils/tests/test_geoip.py
+++ b/karrot/utils/tests/test_geoip.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from geoip2.errors import AddressNotFoundError
+
+from karrot.utils.geoip import ip_to_city, ip_to_lat_lon, geoip_is_available
+
+
+@patch('karrot.utils.geoip.geoip')
+class TestGeoUtils(TestCase):
+    def test_mock_geoip_is_available(self, geoip):
+        self.assertTrue(geoip_is_available())
+
+    def test_to_city_swallows_address_not_found_error(self, geoip):
+        geoip.city.side_effect = AddressNotFoundError
+        self.assertIsNone(ip_to_city('1.2.3.4'))
+
+    def test_to_city_raises_other_errors(self, geoip):
+        geoip.city.side_effect = Exception
+        with self.assertRaises(Exception):
+            ip_to_city('1.2.3.4')
+
+    def test_to_lat_lon_swallows_address_not_found_error(self, geoip):
+        geoip.lat_lon.side_effect = AddressNotFoundError
+        self.assertIsNone(ip_to_lat_lon('1.2.3.4'))
+
+    def test_to_lat_lon_raises_other_errors(self, geoip):
+        geoip.lat_lon.side_effect = Exception
+        with self.assertRaises(Exception):
+            ip_to_lat_lon('1.2.3.4')


### PR DESCRIPTION
To help https://github.com/yunity/karrot-frontend/issues/2355 be implemented this adds `country_code` field to geoip info we return. 

I also added a `timezone` field whilst I was there, which could perhaps be used to only load the client side timezone detection library if it's really needed (via a dynamic import). Just a thought.

This can be manually tested like this:

```
curl -s -H 'X-Forwarded-For: 191.249.32.2' localhost:8000/api/bootstrap/ | jq .geoip
{
  "lat": -19.8993,
  "lng": -43.957,
  "country_code": "BR",
  "timezone": "America/Sao_Paulo"
}
```