### PR TITLE
Add more activity statistics

### DIFF
--- a/karrot/stats/api.py
+++ b/karrot/stats/api.py
@@ -62,11 +62,15 @@ class ActivityHistoryStatsViewSet(ListModelMixin, GenericViewSet):
             .values('place', 'group') \
             .filter(typus__in=[
                 HistoryTypus.ACTIVITY_DONE,
+                HistoryTypus.ACTIVITY_MISSED,
                 HistoryTypus.ACTIVITY_LEAVE,
             ]) \
             .annotate(
                 done_count=Count('activity', filter=Q(
                     typus=HistoryTypus.ACTIVITY_DONE,
+                )),
+                missed_count=Count('activity', filter=Q(
+                    typus=HistoryTypus.ACTIVITY_MISSED,
                 )),
                 leave_count=Count('activity', filter=Q(
                     typus=HistoryTypus.ACTIVITY_LEAVE,
@@ -79,7 +83,11 @@ class ActivityHistoryStatsViewSet(ListModelMixin, GenericViewSet):
                 ),
                 feedback_weight=Coalesce(Sum('activity__feedback__weight', filter=feedback_weight_filter), 0.0)) \
             .filter(
-                Q(done_count__gt=0) | Q(leave_count__gt=0) | Q(leave_late_count__gt=0) | Q(feedback_weight__gt=0)) \
+                Q(done_count__gt=0) |
+                Q(missed_count__gt=0) |
+                Q(leave_count__gt=0) |
+                Q(leave_late_count__gt=0) |
+                Q(feedback_weight__gt=0)) \
             .order_by('place__name')
 
 

--- a/karrot/stats/api.py
+++ b/karrot/stats/api.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.viewsets import GenericViewSet
 
-from karrot.activities.models import Activity
+from karrot.activities.models import Activity, ActivityType
 from karrot.history.models import HistoryTypus, History
 from karrot.stats import stats
 from karrot.stats.serializers import FrontendStatsSerializer, ActivityHistoryStatsSerializer
@@ -32,14 +32,19 @@ def users_queryset(request):
     return get_user_model().objects.filter(groups__in=request.user.groups.all())
 
 
+def activity_type_queryset(request):
+    return ActivityType.objects.filter(group__in=request.user.groups.all())
+
+
 class ActivityHistoryStatsFilter(FilterSet):
     group = ModelChoiceFilter(queryset=groups_queryset)
     user = ModelMultipleChoiceFilter(queryset=users_queryset, field_name='users')
     date = IsoDateTimeFromToRangeFilter(field_name='activity__date__startswith')
+    activity_type = ModelChoiceFilter(queryset=activity_type_queryset, field_name='activity__activity_type')
 
     class Meta:
         model = History
-        fields = ['group', 'user']
+        fields = ['group', 'activity_type', 'user']
 
 
 class ActivityHistoryStatsViewSet(ListModelMixin, GenericViewSet):

--- a/karrot/stats/api.py
+++ b/karrot/stats/api.py
@@ -52,10 +52,10 @@ class ActivityHistoryStatsViewSet(ListModelMixin, GenericViewSet):
     def get_queryset(self):
         user_id = self.request.query_params.get('user', None)
 
-        feedback_weight_filter = Q(typus=HistoryTypus.ACTIVITY_DONE)
+        feedback_filter = Q(typus=HistoryTypus.ACTIVITY_DONE)
 
         if user_id:
-            feedback_weight_filter &= Q(activity__feedback__given_by=user_id)
+            feedback_filter &= Q(activity__feedback__given_by=user_id)
 
         return self.filter_queryset(super().get_queryset()) \
             .annotate_activity_leave_seconds() \
@@ -66,27 +66,29 @@ class ActivityHistoryStatsViewSet(ListModelMixin, GenericViewSet):
                 HistoryTypus.ACTIVITY_LEAVE,
             ]) \
             .annotate(
-                done_count=Count('activity', filter=Q(
+                done_count=Count('activity', distinct=True, filter=Q(
                     typus=HistoryTypus.ACTIVITY_DONE,
                 )),
-                missed_count=Count('activity', filter=Q(
+                missed_count=Count('activity', distinct=True, filter=Q(
                     typus=HistoryTypus.ACTIVITY_MISSED,
                 )),
-                leave_count=Count('activity', filter=Q(
+                leave_count=Count('activity', distinct=True, filter=Q(
                     typus=HistoryTypus.ACTIVITY_LEAVE,
                     activity__in=Activity.objects.done_not_full(),
                 )),
-                leave_late_count=Count('activity', filter=Q(
+                leave_late_count=Count('activity', distinct=True, filter=Q(
                     typus=HistoryTypus.ACTIVITY_LEAVE,
                     activity__in=Activity.objects.done_not_full(),
                     activity_leave_seconds__lte=timedelta(hours=settings.ACTIVITY_LEAVE_LATE_HOURS).total_seconds()),
                 ),
-                feedback_weight=Coalesce(Sum('activity__feedback__weight', filter=feedback_weight_filter), 0.0)) \
+                feedback_count=Count('activity__feedback', filter=feedback_filter),
+                feedback_weight=Coalesce(Sum('activity__feedback__weight', filter=feedback_filter), 0.0)) \
             .filter(
                 Q(done_count__gt=0) |
                 Q(missed_count__gt=0) |
                 Q(leave_count__gt=0) |
                 Q(leave_late_count__gt=0) |
+                Q(feedback_count__gt=0) |
                 Q(feedback_weight__gt=0)) \
             .order_by('place__name')
 

--- a/karrot/stats/serializers.py
+++ b/karrot/stats/serializers.py
@@ -16,6 +16,8 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
     missed_count = serializers.IntegerField()
     leave_count = serializers.IntegerField()
     leave_late_count = serializers.IntegerField()
+    leave_missed_count = serializers.IntegerField()
+    leave_missed_late_count = serializers.IntegerField()
     feedback_count = serializers.IntegerField()
     feedback_weight = serializers.FloatField()
 
@@ -28,6 +30,8 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
             'missed_count',
             'leave_count',
             'leave_late_count',
+            'leave_missed_count',
+            'leave_missed_late_count',
             'feedback_count',
             'feedback_weight',
         ]

--- a/karrot/stats/serializers.py
+++ b/karrot/stats/serializers.py
@@ -13,6 +13,7 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
     group = serializers.IntegerField()
 
     done_count = serializers.IntegerField()
+    missed_count = serializers.IntegerField()
     leave_count = serializers.IntegerField()
     leave_late_count = serializers.IntegerField()
     feedback_weight = serializers.FloatField()
@@ -23,6 +24,7 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
             'place',
             'group',
             'done_count',
+            'missed_count',
             'leave_count',
             'leave_late_count',
             'feedback_weight',

--- a/karrot/stats/serializers.py
+++ b/karrot/stats/serializers.py
@@ -16,6 +16,7 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
     missed_count = serializers.IntegerField()
     leave_count = serializers.IntegerField()
     leave_late_count = serializers.IntegerField()
+    feedback_count = serializers.IntegerField()
     feedback_weight = serializers.FloatField()
 
     class Meta:
@@ -27,6 +28,7 @@ class ActivityHistoryStatsSerializer(serializers.ModelSerializer):
             'missed_count',
             'leave_count',
             'leave_late_count',
+            'feedback_count',
             'feedback_weight',
         ]
 


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/2336 (well, most of it I think). Also see https://community.foodsaving.world/t/more-statistics-display/489/8.

This adds:
- **missed activities** - only relevant if there is no user filter, as a single user can't miss an activity by definition
- **feedback count** - in addition to feedback weight that it already returned
- refined the **left** / **left late** concept, so now:
  - **left** = activities left at any time, which were maybe later fulfilled, or not
  - **left late** = same as above, but left within 24 hours of start
  - **left missed** (_new!_) = activities left at any time, and later were missed (nobody did them)
  - **left late missed** (_new!_) = same as above, but left within 24 hours of start
- filter by **activity type**

Before this PR, both the **left** and **left late** would check that the activities were later _not full_ (rather than missed entirely). I wasn't sure at the time which was better.

With the new way the frontend can calculate the "missed but later fulfilled" value too if needed (`left - left missed`).

I also fixed a bug that I _think_ was double counting stats for activities with multiple feedbacks... I added `distinct` to all the `Count()` calls to resolve that.