### PR TITLE
Message list: split queries to avoid slow cases

### DIFF
--- a/karrot/conversations/models.py
+++ b/karrot/conversations/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import Count, F, Q, Value, IntegerField
+from django.db.models import Count, F, IntegerField, Q
 from django.db.models.manager import BaseManager
 from django.utils import timezone
 from versatileimagefield.fields import VersatileImageField
@@ -241,10 +241,6 @@ class ConversationMessageQuerySet(models.QuerySet):
         return self.filter(
             Q(conversation__participants=user) |
             Q(conversation__group__groupmembership__user=user, conversation__group__isnull=False)
-        ).annotate(
-            has_conversation_access=Value(True, output_field=models.BooleanField())
-            # This is not just an annotation, we use it because it results in a 'group by' clause
-            # It is much faster then the alternative 'distinct' modifier
         )
 
 

--- a/karrot/conversations/tests/test_api.py
+++ b/karrot/conversations/tests/test_api.py
@@ -108,7 +108,7 @@ class TestConversationsAPI(APITestCase):
 
     def test_list_messages(self):
         self.client.force_login(user=self.participant1)
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get('/api/messages/?conversation={}'.format(self.conversation1.id), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 1)
@@ -267,11 +267,12 @@ class TestConversationThreadsAPI(APITestCase):
         self.client.force_login(user=self.user)
         another_thread = self.conversation.messages.create(author=self.user, content='my own thread')
         n = 5
-        [self.create_reply(thread=another_thread) for _ in range(n)]
+        replies = [self.create_reply(thread=another_thread) for _ in range(n)]
 
         response = self.client.get('/api/messages/?thread={}'.format(another_thread.id), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['results']), n + 1)
+        # self.assertEqual(len(response.data['results']), n + 1)
+        self.assertEqual([m['id'] for m in response.data['results']], [another_thread.id] + [m.id for m in replies])
 
     def test_list_my_recently_active_threads(self):
         most_recent_thread = self.conversation.messages.create(author=self.user, content='my own thread')

--- a/karrot/conversations/tests/test_api.py
+++ b/karrot/conversations/tests/test_api.py
@@ -271,8 +271,8 @@ class TestConversationThreadsAPI(APITestCase):
 
         response = self.client.get('/api/messages/?thread={}'.format(another_thread.id), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # self.assertEqual(len(response.data['results']), n + 1)
         self.assertEqual([m['id'] for m in response.data['results']], [another_thread.id] + [m.id for m in replies])
+        self.assertEqual(len(response.data['results']), n + 1)
 
     def test_list_my_recently_active_threads(self):
         most_recent_thread = self.conversation.messages.create(author=self.user, content='my own thread')

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -214,7 +214,7 @@ msgid ""
 msgstr ""
 
 #: karrot/conversations/api.py:65 karrot/conversations/api.py:246
-#: karrot/conversations/api.py:429 karrot/conversations/serializers.py:177
+#: karrot/conversations/api.py:428 karrot/conversations/serializers.py:177
 msgid "You are not in this conversation"
 msgstr ""
 
@@ -229,11 +229,11 @@ msgid ""
 "creation."
 msgstr ""
 
-#: karrot/conversations/api.py:358
+#: karrot/conversations/api.py:357
 msgid "Must be first in thread"
 msgstr ""
 
-#: karrot/conversations/api.py:361
+#: karrot/conversations/api.py:360
 msgid "You are not a participant in this thread"
 msgstr ""
 

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -214,7 +214,7 @@ msgid ""
 msgstr ""
 
 #: karrot/conversations/api.py:65 karrot/conversations/api.py:246
-#: karrot/conversations/api.py:415 karrot/conversations/serializers.py:177
+#: karrot/conversations/api.py:429 karrot/conversations/serializers.py:177
 msgid "You are not in this conversation"
 msgstr ""
 
@@ -229,11 +229,11 @@ msgid ""
 "creation."
 msgstr ""
 
-#: karrot/conversations/api.py:344
+#: karrot/conversations/api.py:358
 msgid "Must be first in thread"
 msgstr ""
 
-#: karrot/conversations/api.py:347
+#: karrot/conversations/api.py:361
 msgid "You are not a participant in this thread"
 msgstr ""
 


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/issues/2369

Moves annotation of replies_count and unread_replies_count into a separate query, to avoid extremely slow cases.

I tested `/api/messages/?conversation=42199` on my machine with the karrot.world production db:
- 95th percentile before: multiple seconds
- 95th percentile after: 460ms