### PR TITLE
Add request and db timeout options

### DIFF
--- a/config/options.env
+++ b/config/options.env
@@ -37,6 +37,12 @@ LISTEN_SOCKET=
 # how many web workers (uvicorn only)
 LISTEN_CONCURRENCY=
 
+# request timeout (daphne only)
+REQUEST_TIMEOUT_SECONDS=60
+
+# database statement query timeout during requests
+REQUEST_DATABASE_TIMEOUT_SECONDS=60
+
 # File upload details (required)
 #-----------------------------------------------
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -208,9 +208,11 @@ DATABASES = {
         'USER': options['DATABASE_USER'],
         'PASSWORD': options['DATABASE_PASSWORD'],
         'HOST': options['DATABASE_HOST'],
-        'PORT': options['DATABASE_PORT'],
+        'PORT': options['DATABASE_PORT']
     }
 }
+
+REQUEST_DATABASE_TIMEOUT_MILLISECONDS = int(options['REQUEST_DATABASE_TIMEOUT_SECONDS']) * 1000
 
 REDIS_HOST = options['REDIS_HOST']
 REDIS_PORT = options['REDIS_PORT']
@@ -442,6 +444,7 @@ LISTEN_CONCURRENCY = int(options['LISTEN_CONCURRENCY'])
 # twisted endpoint (for daphne)
 LISTEN_ENDPOINT = options['LISTEN_ENDPOINT']
 
+REQUEST_TIMEOUT_SECONDS = int(options['REQUEST_TIMEOUT_SECONDS'])
 
 # If you have the email_reply_trimmer_service running, set this to 'http://localhost:4567/trim' (or similar)
 # https://github.com/yunity/email_reply_trimmer_service

--- a/karrot/cli.py
+++ b/karrot/cli.py
@@ -109,6 +109,9 @@ def server_daphne():
     args += ['--ws-protocol', 'karrot.token']
     args += ['--proxy-headers']
 
+    if settings.REQUEST_TIMEOUT_SECONDS:
+        args += ['--http-timeout', str(settings.REQUEST_TIMEOUT_SECONDS)]
+
     if settings.LISTEN_CONCURRENCY > 1:
         raise Exception('LISTEN_CONCURRENCY cannot be above 1 if using daphne')
 


### PR DESCRIPTION
Relating to https://github.com/yunity/karrot-frontend/issues/2369

These timeouts are to improve handling the situation where they are excessively slow db queries:
1. a db statement timeout, this means postgres will abort the query when it reaches that limit
2. daphne request timeout, so the webserver will abort the request

I set the defaults both to 60 seconds, but might be a good idea to set them to shorter values in production, as 60s is pretty unusable...

The idea is to avoid blocking the server processes and database connections with long running queries.