### PR TITLE
place statistics: avoid slow EXISTS query

### DIFF
--- a/karrot/activities/models.py
+++ b/karrot/activities/models.py
@@ -212,7 +212,8 @@ class ActivityQuerySet(models.QuerySet):
         return self.exclude_disabled().filter(date__startswith__lt=timezone.now(), participants=None)
 
     def done(self):
-        return self.exclude_disabled().filter(date__startswith__lt=timezone.now()).exclude(participants=None)
+        return self.exclude_disabled().filter(date__startswith__lt=timezone.now())\
+            .annotate_num_participants().filter(num_participants__gt=0)
 
     def done_not_full(self):
         return self.exclude_disabled() \


### PR DESCRIPTION
Django 3.2 ORM uses SQL EXISTS statement for `exclude(participants=None)`. For some reason, this causes PostgreSQL to run the query for place statistics for multiple minutes.

This commit uses `annotate` and `filter` to avoid this situation.

Related chat: https://chat.foodsaving.world/channel/karrot-dev?msg=sbPugdDzSvBEHv53F

Generated SQL:
```sql
SELECT "places_place"."id",
       "places_place"."created_at",
       "places_place"."address",
       "places_place"."latitude",
       "places_place"."longitude",
       "places_place"."group_id",
       "places_place"."name",
       "places_place"."description",
       "places_place"."weeks_in_advance",
       "places_place"."status",
       "places_place"."last_changed_by_id",
       COUNT(DISTINCT "activities_feedback"."id") AS "feedback_count",
       COUNT(DISTINCT "activities_activity"."id") FILTER (
           WHERE "activities_activity"."id" IN
                 (SELECT U0."id"
                  FROM "activities_activity" U0
                           INNER JOIN "places_place" U1 ON (U0."place_id" = U1."id")
                           INNER JOIN "groups_group" U2 ON (U1."group_id" = U2."id")
                           LEFT OUTER JOIN "activities_activity_participants" U3 ON (U0."id" = U3."activity_id")
                  WHERE (NOT U0."is_disabled"
                      AND lower(U0."date") < '2021-06-02T18:25:17.390262+00:00'::timestamptz)
                  GROUP BY U0."id"
                  HAVING COUNT(U3."user_id") > 0)) AS "activities_done"
FROM "places_place"
         INNER JOIN "groups_group" ON ("places_place"."group_id" = "groups_group"."id")
         INNER JOIN "groups_group_members" ON ("groups_group"."id" = "groups_group_members"."group_id")
         LEFT OUTER JOIN "activities_activity" ON ("places_place"."id" = "activities_activity"."place_id")
         LEFT OUTER JOIN "activities_feedback" ON ("activities_activity"."id" = "activities_feedback"."about_id")
WHERE ("groups_group_members"."user_id" = 17
    AND "places_place"."id" = 389)
GROUP BY "places_place"."id"
LIMIT 21 ```

Django 3.2 with `exclude`:
```sql
SELECT "places_place"."id",
       "places_place"."created_at",
       "places_place"."address",
       "places_place"."latitude",
       "places_place"."longitude",
       "places_place"."group_id",
       "places_place"."name",
       "places_place"."description",
       "places_place"."weeks_in_advance",
       "places_place"."status",
       "places_place"."last_changed_by_id",
       COUNT(DISTINCT "activities_feedback"."id") AS "feedback_count",
       COUNT(DISTINCT "activities_activity"."id") FILTER (
           WHERE "activities_activity"."id" IN
                 (SELECT V0."id"
                  FROM "activities_activity" V0
                           INNER JOIN "places_place" V1 ON (V0."place_id" = V1."id")
                           INNER JOIN "groups_group" V2 ON (V1."group_id" = V2."id")
                  WHERE (NOT V0."is_disabled"
                      AND lower(V0."date") < '2021-06-02T10:20:33.897927+00:00'::timestamptz
                      AND NOT (EXISTS
                          (SELECT (1) AS "a"
                           FROM "activities_activity" U0
                                    LEFT OUTER JOIN "activities_activity_participants" U1 ON (U0."id" = U1."activity_id")
                           WHERE (U1."user_id" IS NULL
                               AND U0."id" = V0."id")
                           LIMIT 1))))) AS "activities_done"
FROM "places_place"
         INNER JOIN "groups_group" ON ("places_place"."group_id" = "groups_group"."id")
         INNER JOIN "groups_group_members" ON ("groups_group"."id" = "groups_group_members"."group_id")
         LEFT OUTER JOIN "activities_activity" ON ("places_place"."id" = "activities_activity"."place_id")
         LEFT OUTER JOIN "activities_feedback" ON ("activities_activity"."id" = "activities_feedback"."about_id")
WHERE ("groups_group_members"."user_id" = 3815
    AND "places_place"."id" = 389)
GROUP BY "places_place"."id"
LIMIT 21
```

Django before 3.2 with `exclude`:
```sql
SELECT "places_place"."id",
       "places_place"."created_at",
       "places_place"."address",
       "places_place"."latitude",
       "places_place"."longitude",
       "places_place"."group_id",
       "places_place"."name",
       "places_place"."description",
       "places_place"."weeks_in_advance",
       "places_place"."status",
       "places_place"."last_changed_by_id",
       COUNT(DISTINCT "activities_feedback"."id") AS "feedback_count",
       COUNT(DISTINCT "activities_activity"."id") FILTER (
           WHERE "activities_activity"."id" IN
                 (SELECT V0."id"
                  FROM "activities_activity" V0
                           INNER JOIN "places_place" V1 ON (V0."place_id" = V1."id")
                           INNER JOIN "groups_group" V2 ON (V1."group_id" = V2."id")
                  WHERE (NOT V0."is_disabled"
                      AND lower(V0."date") < '2021-06-02T16:20:30.461760+00:00'::timestamptz
                      AND NOT (V0."id" IN
                               (SELECT U0."id"
                                FROM "activities_activity" U0
                                         LEFT OUTER JOIN "activities_activity_participants" U1 ON (U0."id" = U1."activity_id")
                                WHERE U1."user_id" IS NULL))))) AS "activities_done"
FROM "places_place"
         INNER JOIN "groups_group" ON ("places_place"."group_id" = "groups_group"."id")
         INNER JOIN "groups_group_members" ON ("groups_group"."id" = "groups_group_members"."group_id")
         LEFT OUTER JOIN "activities_activity" ON ("places_place"."id" = "activities_activity"."place_id")
         LEFT OUTER JOIN "activities_feedback" ON ("activities_activity"."id" = "activities_feedback"."about_id")
WHERE ("groups_group_members"."user_id" = 17
    AND "places_place"."id" = 389)
GROUP BY "places_place"."id"
LIMIT 21
```