### PR TITLE
activity-list enpoint: avoid n+1 queries

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -213,10 +213,10 @@ class ActivityViewSet(
 
     def get_queryset(self):
         qs = self.queryset.filter(place__group__members=self.request.user, place__status=PlaceStatus.ACTIVE.value)
-        if self.action == 'list':
+        if self.action in ('retrieve', 'list'):
             # because we have participants field in the serializer
             # only prefetch on read_only actions, otherwise there are caching problems when participants get added
-            qs = qs.prefetch_related('activityparticipant_set', 'feedback_given_by')
+            qs = qs.select_related('activity_type').prefetch_related('activityparticipant_set', 'feedback_given_by')
         if self.action == 'add':
             # Lock activity when adding a participant
             # This should prevent a race condition that would result in more participants than slots

--- a/karrot/activities/tests/test_activities_api.py
+++ b/karrot/activities/tests/test_activities_api.py
@@ -119,7 +119,8 @@ class TestActivitiesAPI(APITestCase, ExtractPaginationMixin):
 
     def test_list_activities_as_group_member(self):
         self.client.force_login(user=self.member)
-        response = self.get_results(self.url)
+        with self.assertNumQueries(4):
+            response = self.get_results(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(len(response.data), 2)
 
@@ -134,7 +135,8 @@ class TestActivitiesAPI(APITestCase, ExtractPaginationMixin):
 
     def test_retrieve_activities_as_group_member(self):
         self.client.force_login(user=self.member)
-        response = self.client.get(self.activity_url)
+        with self.assertNumQueries(4):
+            response = self.client.get(self.activity_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
     def test_patch_activity(self):


### PR DESCRIPTION
Looking up `activity_type` caused n queries. The endpoint is used frequently, so it seems better to avoid this.

This should roughly halve mean response time from 400ms to 200ms. For groups with lots of activities, response time was around 700ms - there's no pagination (yet).

I applied the same optimization to `activity-retrieve`.