### PR TITLE
Switch to drf-spectacular for API documentation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -158,6 +158,13 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'Karrot API',
     'DESCRIPTION': '_could link to rocket chat or community forum here_',
     'VERSION': '0.1',
+    'SCHEMA_PATH_PREFIX': '/api/',
+    'SWAGGER_UI_FAVICON_HREF': '/favicon.ico',
+    'SWAGGER_UI_SETTINGS': {
+        'deepLinking': True,
+        'defaultModelsExpandDepth': 0,
+        'docExpansion': 'none',
+    },
 }
 
 MIDDLEWARE = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -134,7 +134,7 @@ INSTALLED_APPS = (
     'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',
-    'rest_framework_swagger',
+    'drf_spectacular',
     'anymail',
     'timezone_field',
     'django_jinja',
@@ -151,7 +151,13 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'EXCEPTION_HANDLER': 'karrot.utils.misc.custom_exception_handler',
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Karrot API',
+    'DESCRIPTION': '_could link to rocket chat or community forum here_',
+    'VERSION': '0.1',
 }
 
 MIDDLEWARE = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -156,7 +156,12 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Karrot API',
-    'DESCRIPTION': '_could link to rocket chat or community forum here_',
+    'DESCRIPTION': """
+Welcome to our API documentation!
+
+Check out our code on [GitHub](https://github.com/yunity/karrot-frontend)
+and talk with us on the [Foodsaving Worldwide Rocketchat](https://chat.foodsaving.world)!
+    """,
     'VERSION': '0.1',
     'SCHEMA_PATH_PREFIX': '/api/',
     'SWAGGER_UI_FAVICON_HREF': '/favicon.ico',

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,9 +8,9 @@ from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path, re_path, include
 from django.views.static import serve
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
-from rest_framework_swagger.views import get_swagger_view
 
 from karrot.applications.api import ApplicationViewSet
 from karrot.bootstrap.api import BootstrapViewSet, ConfigViewSet
@@ -106,7 +106,8 @@ urlpatterns = [
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('admin/docs/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
-    path('docs/', get_swagger_view()),
+    path('docs/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/anymail/', include('anymail.urls')),
     re_path(r'^silk/', include('silk.urls', namespace='silk'))
 ]

--- a/karrot/conversations/api.py
+++ b/karrot/conversations/api.py
@@ -1,4 +1,3 @@
-import coreapi
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -7,6 +6,8 @@ from django.http import Http404
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import mixins
 from rest_framework import status
 from rest_framework.decorators import action
@@ -16,7 +17,6 @@ from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated, BasePermission
 from rest_framework.response import Response
-from rest_framework.schemas import ManualSchema
 from rest_framework.viewsets import GenericViewSet
 
 from karrot.applications.models import Application
@@ -316,16 +316,16 @@ class ConversationMessageViewSet(
         serializer = self.get_serializer(messages, many=True)
         return self.get_paginated_response(serializer.data)
 
+    @extend_schema(
+        description='Lists threads the user has participated in',
+        parameters=[
+            OpenApiParameter('group', OpenApiTypes.INT, OpenApiParameter.QUERY),
+            OpenApiParameter('conversation', OpenApiTypes.INT, OpenApiParameter.QUERY),
+            OpenApiParameter('exclude_read', OpenApiTypes.BOOL, OpenApiParameter.QUERY),
+        ]
+    )
     @action(
         detail=False,
-        schema=ManualSchema(
-            description='Lists threads the user has participated in',
-            fields=[
-                coreapi.Field('group', location='query'),
-                coreapi.Field('conversation', location='query'),
-                coreapi.Field('exclude_read', location='query'),
-            ]
-        )
     )
     def my_threads(self, request):
         queryset = ConversationMessage.objects.distinct() \

--- a/karrot/tests/integration/test_swagger.py
+++ b/karrot/tests/integration/test_swagger.py
@@ -7,18 +7,17 @@ from karrot.users.factories import UserFactory
 class TestSwaggerAPI(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        self.url = '/docs/'
 
-    def test_swagger_coreapi(self):
+    def test_swagger_openapi(self):
         self.client.force_login(user=self.user)
-        response = self.client.get(self.url)
-        self.assertEqual(response.accepted_media_type, 'application/coreapi+json')
+        response = self.client.get('/docs/schema/')
+        self.assertEqual(response.accepted_media_type, 'application/vnd.oai.openapi')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('agreements', response.data)
-        self.assertIn('groups', response.data)
+        self.assertIn('/api/agreements/', response.data['paths'])
+        self.assertIn('/api/groups/', response.data['paths'])
 
     def test_swagger_html(self):
         self.client.force_login(user=self.user)
-        response = self.client.get(self.url, HTTP_ACCEPT='text/html')
+        response = self.client.get('/docs/')
         self.assertEqual(response.accepted_media_type, 'text/html')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/karrot/utils/templates/drf_spectacular/swagger_ui.html
+++ b/karrot/utils/templates/drf_spectacular/swagger_ui.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Karrot API Documentation</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% if favicon_href %}
+    <link rel="icon" type="image/png" href="{{favicon_href}}"/>
+  {% endif %}
+  <link rel="stylesheet" type="text/css" href="{{dist}}/swagger-ui.css" />
+  <style>
+    /* hide swagger-ui login options, they don't help us very much */
+    .scheme-container {
+      display: none;
+    }
+    .django-auth-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding-top: 5px;
+      padding-bottom: 15px;
+      border-bottom: 1px lightgrey solid;
+    }
+  </style>
+</head>
+<body>
+<div class="swagger-ui">
+  <div class="wrapper">
+    <div class="django-auth-bar">
+      <div>
+        {% if request.user.is_authenticated %}
+          You are logged in as: <strong>{{ request.user }}</strong>
+        {% else %}
+          Viewing as an anonymous user
+        {% endif %}
+      </div>
+      <div>
+        {% if request.user.is_authenticated %}
+          <a class="btn" style="text-decoration: none" href="{% url 'rest_framework:logout' %}?next={{ request.path }}">Logout</a>
+        {% else %}
+          <a class="btn" style="text-decoration: none" href="{% url 'rest_framework:login' %}?next={{ request.path }}">Session Login</a>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+<div id="swagger-ui"></div>
+<script src="{{dist}}/swagger-ui-bundle.js"></script>
+{% if script_url %}
+  <script src="{{script_url|safe}}"></script>
+{% else %}
+  <script>
+    {% include template_name_js %}
+  </script>
+{% endif %}
+</body>
+</html>

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,3 @@
-# This is not maintained anymore
--e git+https://github.com/tiltec/django-rest-swagger@d15dd9a#egg=django-rest-swagger
-
 # Removes machine learning dependencies
 # Zulip maintains their own fork:
 # https://github.com/zulip/zulip/blob/61e1e38a00f4ef9fe4c1a302b93ce059646c62a6/requirements/common.in#L60-L61
@@ -19,6 +16,7 @@ django-redis
 django-dirtyfields
 djangorestframework
 djangorestframework-csv
+drf-spectacular
 django-jinja
 hiredis
 markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #    pip-compile --no-annotate
 #
 -e git+https://github.com/anymail/django-anymail@e90c10b#egg=django-anymail
--e git+https://github.com/tiltec/django-rest-swagger@d15dd9a#egg=django-rest-swagger
 -e git+https://github.com/tiltec/talon@80886cd#egg=talon
 aiofiles==0.6.0
 aiohttp==3.7.4.post0
@@ -34,8 +33,6 @@ channels==3.0.3
 chardet==4.0.0
 click==7.1.2
 constantly==15.1.0
-coreapi==2.3.3
-coreschema==0.0.4
 coverage==5.5
 cryptography==3.4.7
 cssselect==1.1.0
@@ -56,6 +53,7 @@ django-versatileimagefield==2.0
 django[argon2]==3.2
 djangorestframework-csv==2.1.0
 djangorestframework==3.12.4
+drf-spectacular==0.17.0
 execnet==1.8.0
 face==20.1.1
 factory-boy==3.2.0
@@ -83,13 +81,14 @@ identify==2.2.4
 idna==2.10
 importlib-metadata==4.0.1
 incremental==21.3.0
+inflection==0.5.1
 influxdb==5.3.1
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 ipython==7.23.0
-itypes==1.2.0
 jedi==0.18.0
 jinja2==2.11.3
+jsonschema==3.2.0
 logging-tree==1.9
 lxml==4.6.3
 markdown==3.3.4
@@ -101,7 +100,6 @@ more-itertools==8.7.0
 msgpack==1.0.2
 multidict==5.1.0
 nodeenv==1.6.0
-openapi-codec==1.3.2
 orderedmultidict==1.0.1
 packaging==20.9
 parso==0.8.2
@@ -126,6 +124,7 @@ pygments==2.8.1
 pymdown-extensions==8.1.1
 pyopenssl==20.0.1
 pyparsing==2.4.7
+pyrsistent==0.17.3
 pytest-asyncio==0.15.1
 pytest-cov==2.11.1
 pytest-django==4.2.0
@@ -145,7 +144,6 @@ requests==2.25.1
 rfc3986[idna2008]==1.4.0
 service-identity==18.1.0
 shiv==0.5.2
-simplejson==3.17.2
 six==1.15.0
 sniffio==1.2.0
 sqlparse==0.4.1


### PR DESCRIPTION
[django-rest-swagger](https://github.com/marcgibbons/django-rest-swagger) has been unmaintained for a long time and we rely on [our fork that contains a custom fix](https://github.com/tiltec/django-rest-swagger). Might be good to switch before some Django/DRF/Python version upgrade forces us to.

[drf-spectacular](https://github.com/tfranzel/drf-spectacular) seems the most up-to-date replacement. The alternative, drf-yasg, recommends using drf-spectacular for new projects because it uses OpenAPI 3.0 (https://github.com/axnsan12/drf-yasg).

Documentation seems nice, especially how to customize the generated schema: https://drf-spectacular.readthedocs.io/en/latest/customization.html

As before, I set it up to serve swagger-ui at `/docs/`. swagger-ui uses a new endpoint to get the schema at `/docs/schema/`.

![image](https://user-images.githubusercontent.com/4410802/121552579-dcf0fb00-ca10-11eb-83f4-adbebbd10a89.png)

The swagger-ui version is upgraded, looks similar but differs in many details. Notable differences:
- reloading respects previous position on the page, by using html anchors - very useful for fiddling with schema modifications
- long list of all schemas at the bottom, some with confusing names (`PatchedOffer`?) - EDIT: now collapsed by default!
- a bit slower to load
- ~~collapsible groups moved one level higher, which make them useless~~

I think it should be possible to fix the collapsing by having the root at `/api/` instead of `/`, I didn't check yet. EDIT: now collapsed!

Also, drf-spectacular gives useful warnings when running `manage.py spectacular --file schema.yaml --validate` on the command line, e.g. about cases where it couldn't identify the schema for some endpoint. Could be useful to run this in CI or pre-push hook to make/keep our documentation top-notch :)
UPDATE: with the test now retrieving `/docs/schema/`, these warnings show up during normal test runs.