### PR TITLE
GroupPreviewSerializer: remove member list and add annotations to improve performance

### DIFF
--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -55,7 +55,7 @@ class BootstrapViewSet(GenericViewSet):
             'config': get_config_data(),
             'user': user if user.is_authenticated else None,
             'geoip': geo_data,
-            'groups': Group.objects.prefetch_related('members'),
+            'groups': Group.objects.annotate_member_count().annotate_is_user_member(user),
         }
 
         serializer = BootstrapSerializer(data, context=self.get_serializer_context())

--- a/karrot/bootstrap/tests/test_api.py
+++ b/karrot/bootstrap/tests/test_api.py
@@ -49,7 +49,8 @@ class TestBootstrapAPI(APITestCase):
         ip_to_city.cache_clear()  # prevent getting cached mock values
 
     def test_as_anon(self):
-        response = self.client.get(self.url)
+        with self.assertNumQueries(1):
+            response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['server'], ANY)
         self.assertEqual(response.data['config'], ANY)
@@ -82,6 +83,7 @@ class TestBootstrapAPI(APITestCase):
 
     def test_when_logged_in(self):
         self.client.force_login(user=self.user)
-        response = self.client.get(self.url)
+        with self.assertNumQueries(2):
+            response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['user']['id'], self.user.id)

--- a/karrot/groups/api.py
+++ b/karrot/groups/api.py
@@ -68,11 +68,18 @@ class GroupInfoViewSet(
     - `?search` - search in name and public description
     - `?include_empty` - set to False to exclude empty groups without members
     """
-    queryset = GroupModel.objects.prefetch_related('members')
+    queryset = GroupModel.objects
     filter_backends = (SearchFilter, filters.DjangoFilterBackend)
     filterset_class = GroupsInfoFilter
     search_fields = ('name', 'public_description')
     serializer_class = GroupPreviewSerializer
+
+    def get_queryset(self):
+        qs = self.queryset
+        if self.action == 'list':
+            qs = qs.annotate_member_count().annotate_is_user_member(self.request.user)
+
+        return qs
 
     @action(
         detail=True,

--- a/karrot/groups/models.py
+++ b/karrot/groups/models.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import TextField, DateTimeField, QuerySet, Count, Q, F
+from django.db.models import TextField, DateTimeField, QuerySet, Count, Q, F, Exists, OuterRef, Value
 from django.db.models.manager import BaseManager
 from django.template.loader import render_to_string
 from django.utils import timezone as tz, timezone
@@ -49,6 +49,15 @@ class GroupQuerySet(models.QuerySet):
                 )
             )
         )
+
+    def annotate_member_count(self):
+        return self.annotate(member_count=Count('groupmembership'))
+
+    def annotate_is_user_member(self, user):
+        if not user or user.is_anonymous:
+            return self.annotate(is_user_member=Value(False))
+        member = GroupMembership.objects.filter(user=user, group=OuterRef('pk'))
+        return self.annotate(is_user_member=Exists(member))
 
 
 class GroupManager(BaseManager.from_queryset(GroupQuerySet)):

--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -370,9 +370,8 @@ class GroupPreviewSerializer(GroupBaseSerializer):
         return group.get_application_questions_or_default()
 
     def get_member_count(self, group) -> int:
-        annotated = getattr(group, 'member_count', None)
-        if annotated is not None:
-            return annotated
+        if hasattr(group, 'member_count'):
+            return group.member_count
 
         return group.members.count()
 
@@ -381,9 +380,8 @@ class GroupPreviewSerializer(GroupBaseSerializer):
         if not user or user.is_anonymous:
             return False
 
-        annotated = getattr(group, 'is_user_member', None)
-        if annotated is not None:
-            return annotated
+        if hasattr(group, 'is_user_member'):
+            return group.is_user_member
 
         return user in group.members.all()
 

--- a/karrot/groups/tests/test_api.py
+++ b/karrot/groups/tests/test_api.py
@@ -26,15 +26,20 @@ class TestGroupsInfoAPI(APITestCase):
         self.user = UserFactory()
         self.member = UserFactory()
         self.group = GroupFactory(members=[self.member], application_questions='')
+        GroupFactory(application_questions='')
         self.url = '/api/groups-info/'
 
     def test_list_groups_as_anon(self):
-        response = self.client.get(self.url)
+        with self.assertNumQueries(1):
+            response = self.client.get(self.url)
+        self.assertEqual(len(response.data), 2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_groups_as_user(self):
         self.client.force_login(user=self.user)
-        response = self.client.get(self.url)
+        with self.assertNumQueries(2):
+            response = self.client.get(self.url)
+        self.assertEqual(len(response.data), 2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_retrieve_group_as_anon(self):
@@ -76,7 +81,7 @@ class TestGroupsInfoAPI(APITestCase):
         for _ in range(randint(3, 5)):
             GroupFactory().add_member(UserFactory())
         self.client.force_login(user=self.user)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             self.client.get(self.url)
 
 

--- a/karrot/groups/tests/test_serializers.py
+++ b/karrot/groups/tests/test_serializers.py
@@ -27,6 +27,6 @@ class TestGroupSerializer(TestCase):
 
     def test_preview(self):
         serializer = GroupPreviewSerializer(self.group)
-        self.assertEqual(len(serializer.data.keys()), 15)
+        self.assertEqual(len(serializer.data.keys()), 14)
         self.assertEqual(serializer.data['id'], self.group.id)
         self.assertEqual(serializer.data['name'], self.group.name)

--- a/karrot/issues/models.py
+++ b/karrot/issues/models.py
@@ -134,10 +134,10 @@ class Voting(BaseModel):
         return self.expires_at < timezone.now()
 
     def participant_count(self) -> int:
-        count = getattr(self, '_participant_count', None)
-        if count is None:
-            count = get_user_model().objects.filter(votes_given__option__voting=self).distinct().count()
-        return count
+        if hasattr(self, '_participant_count'):
+            return self._participant_count
+
+        return get_user_model().objects.filter(votes_given__option__voting=self).distinct().count()
 
     def create_options(self):
         options = [

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -214,7 +214,7 @@ msgid ""
 msgstr ""
 
 #: karrot/conversations/api.py:65 karrot/conversations/api.py:246
-#: karrot/conversations/api.py:429 karrot/conversations/serializers.py:186
+#: karrot/conversations/api.py:429 karrot/conversations/serializers.py:187
 msgid "You are not in this conversation"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "New message for offer %(offer_name)s in %(group_name)s"
 msgstr ""
 
-#: karrot/conversations/serializers.py:188
+#: karrot/conversations/serializers.py:189
 msgid "This conversation has been closed"
 msgstr ""
 

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -294,7 +294,7 @@ msgstr ""
 msgid "You cannot give trust to yourself"
 msgstr ""
 
-#: karrot/groups/api.py:200
+#: karrot/groups/api.py:207
 msgid "You already gave trust to this user"
 msgstr ""
 

--- a/karrot/offers/tests/test_api.py
+++ b/karrot/offers/tests/test_api.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from rest_framework import status
-from rest_framework.test import APITestCase, APITransactionTestCase
+from rest_framework.test import APITestCase
 
 from karrot.groups.factories import GroupFactory
 from karrot.offers.factories import OfferFactory
@@ -163,7 +163,7 @@ class TestOffersAPI(APITestCase):
 
 
 @patch('karrot.offers.emails.prepare_email')
-class TestOffersTransactionAPI(APITransactionTestCase):
+class TestOffersTransactionAPI(APITestCase):
     def setUp(self):
         self.user = VerifiedUserFactory()
         self.another_user = VerifiedUserFactory()
@@ -181,7 +181,8 @@ class TestOffersTransactionAPI(APITransactionTestCase):
                     'image': image_file
                 }],
             }
-            response = self.client.post('/api/offers/', data=encode_data_with_images(data))
+            with self.captureOnCommitCallbacks(execute=True):
+                response = self.client.post('/api/offers/', data=encode_data_with_images(data))
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
             args, kwargs = prepare_email.call_args
             self.assertIsNotNone(kwargs['context']['offer_photo'])

--- a/karrot/subscriptions/receivers.py
+++ b/karrot/subscriptions/receivers.py
@@ -244,15 +244,44 @@ def send_group_membership_updates(sender, instance, created, **kwargs):
         # notification types are only visible to one user
         send_group_detail(group, user=membership.user)
 
+
+@receiver(post_save, sender=GroupMembership)
+@on_transaction_commit
+def send_group_membership_updates_on_commit(sender, instance, created, **kwargs):
+    membership = instance
+    group = membership.group
+
     if created:
         send_group_preview(group)
+        for subscription in ChannelSubscription.objects.recent().filter(user__in=group.members.all()):
+            send_in_channel(
+                subscription.reply_channel,
+                topic='groups:user_joined',
+                payload={
+                    'user_id': membership.user_id,
+                    'group_id': group.id,
+                }
+            )
 
 
 @receiver(post_delete, sender=GroupMembership)
+@on_transaction_commit
 def send_group_member_left(sender, instance, **kwargs):
-    group = instance.group
+    membership = instance
+    group = membership.group
+
     send_group_detail(group)
     send_group_preview(group)
+    for subscription in ChannelSubscription.objects.recent().filter(Q(user__in=group.members.all()) |
+                                                                    Q(user_id=membership.user_id)):
+        send_in_channel(
+            subscription.reply_channel,
+            topic='groups:user_left',
+            payload={
+                'user_id': membership.user_id,
+                'group_id': group.id,
+            }
+        )
 
 
 # Applications

--- a/karrot/subscriptions/receivers.py
+++ b/karrot/subscriptions/receivers.py
@@ -211,8 +211,8 @@ def send_group_detail(group, user=None):
 
 
 def send_group_preview(group):
-    preview_payload = GroupPreviewSerializer(group).data
     for subscription in ChannelSubscription.objects.recent():
+        preview_payload = GroupPreviewSerializer(group, context={'request': MockRequest(user=subscription.user)}).data
         send_in_channel(subscription.reply_channel, topic='groups:group_preview', payload=preview_payload)
 
 

--- a/karrot/subscriptions/tests/test_receivers.py
+++ b/karrot/subscriptions/tests/test_receivers.py
@@ -522,18 +522,21 @@ class GroupMembershipReceiverTests(WSTestCase):
         self.assertIn(self.user.id, response['payload']['memberships'].keys())
 
         response = member_client.messages_by_topic.get('groups:group_preview')[0]
-        self.assertIn(self.user.id, response['payload']['members'])
+        self.assertTrue(response['payload']['is_member'])
+        self.assertEqual(2, response['payload']['member_count'])
         self.assertNotIn('memberships', response['payload'])
 
         response = joining_client.messages_by_topic.get('groups:group_detail')[0]
         self.assertIn(self.user.id, response['payload']['members'])
 
         response = joining_client.messages_by_topic.get('groups:group_preview')[0]
-        self.assertIn(self.user.id, response['payload']['members'])
+        self.assertTrue(response['payload']['is_member'])
+        self.assertEqual(2, response['payload']['member_count'])
 
         self.assertNotIn('groups:group_detail', nonmember_client.messages_by_topic.keys())
         response = nonmember_client.messages_by_topic.get('groups:group_preview')[0]
-        self.assertIn(self.user.id, response['payload']['members'])
+        self.assertFalse(response['payload']['is_member'])
+        self.assertEqual(2, response['payload']['member_count'])
         self.assertNotIn('memberships', response['payload'])
 
     def test_receive_group_leave_as_leaving_user(self):
@@ -544,7 +547,7 @@ class GroupMembershipReceiverTests(WSTestCase):
         self.group.remove_member(self.member)
 
         response = client.messages_by_topic.get('groups:group_preview')[0]
-        self.assertNotIn(self.user.id, response['payload']['members'])
+        self.assertFalse(response['payload']['is_member'])
         self.assertNotIn('memberships', response['payload'])
         self.assertEqual([m['topic'] for m in client.messages], [
             'history:history',

--- a/karrot/subscriptions/tests/test_receivers.py
+++ b/karrot/subscriptions/tests/test_receivers.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 
@@ -135,20 +135,7 @@ class WSTestCase(TestCase):
         return client
 
 
-class WSTransactionTestCase(TransactionTestCase):
-    def setUp(self):
-        super().setUp()
-        self.send_in_channel_patcher = patch('karrot.subscriptions.receivers.send_in_channel')
-        self.send_in_channel_mock = self.send_in_channel_patcher.start()
-        self.addCleanup(self.send_in_channel_patcher.stop)
-
-    def connect_as(self, user):
-        client = WSClient(self.send_in_channel_mock)
-        client.connect_as(user)
-        return client
-
-
-class ConversationReceiverTests(WSTransactionTestCase):
+class ConversationReceiverTests(WSTestCase):
     def test_receives_messages(self):
         self.maxDiff = None
         user = UserFactory()
@@ -162,7 +149,8 @@ class ConversationReceiverTests(WSTransactionTestCase):
         author_client = self.connect_as(author)
 
         # add a message to the conversation
-        message = ConversationMessage.objects.create(conversation=conversation, content='yay', author=author)
+        with self.captureOnCommitCallbacks(execute=True):
+            message = ConversationMessage.objects.create(conversation=conversation, content='yay', author=author)
 
         # hopefully they receive it!
         ws_messages = client.messages_by_topic
@@ -197,14 +185,15 @@ class ConversationReceiverTests(WSTransactionTestCase):
         )
 
         # author should get message & updated conversations object too
-        response = author_client.messages[0]
+        author_messages = author_client.messages_by_topic
+        response = author_messages['conversations:message'][0]
         parse_dates(response)
         self.assertEqual(response, make_conversation_message_broadcast(message, is_editable=True))
 
         # Author receives more recent `update_at` time,
         # because their `seen_up_to` status is set after sending the message.
         author_participant = conversation.conversationparticipant_set.get(user=author)
-        response = author_client.messages[1]
+        response = author_messages['conversations:conversation'][0]
         parse_dates(response)
         del response['payload']['participants']
         self.assertEqual(
@@ -293,7 +282,7 @@ class ConversationReceiverTests(WSTransactionTestCase):
         )
 
 
-class ConversationThreadReceiverTests(WSTransactionTestCase):
+class ConversationThreadReceiverTests(WSTestCase):
     def test_receives_messages(self):
         self.maxDiff = None
         op_user = UserFactory()  # op: original post
@@ -306,12 +295,13 @@ class ConversationThreadReceiverTests(WSTransactionTestCase):
         op_client = self.connect_as(op_user)
         author_client = self.connect_as(author)
 
-        reply = ConversationMessage.objects.create(
-            conversation=conversation,
-            thread=thread,
-            content='really yay?',
-            author=author,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            reply = ConversationMessage.objects.create(
+                conversation=conversation,
+                thread=thread,
+                content='really yay?',
+                author=author,
+            )
 
         op_messages = op_client.messages_by_topic
 
@@ -357,13 +347,14 @@ class ConversationThreadReceiverTests(WSTransactionTestCase):
         )
 
         # reply author should get message too
-        response = author_client.messages[0]
+        author_messages = author_client.messages_by_topic
+        response = author_messages['conversations:message'][0]
         parse_dates(response)
         self.assertEqual(response, make_conversation_message_broadcast(reply, is_editable=True, thread=thread.id))
 
         # Author receives more recent `update_at` time,
         # because their `seen_up_to` status is set after sending the message.
-        response = author_client.messages[1]
+        response = author_messages['conversations:message'][1]
         parse_dates(response)
         self.assertEqual(
             response,
@@ -411,7 +402,7 @@ class ConversationThreadReceiverTests(WSTransactionTestCase):
         )
 
 
-class ConversationMessageReactionReceiverTests(WSTransactionTestCase):
+class ConversationMessageReactionReceiverTests(WSTestCase):
     def test_receive_reaction_update(self):
         self.maxDiff = None
         author, user, reaction_user = [UserFactory() for _ in range(3)]
@@ -422,11 +413,12 @@ class ConversationMessageReactionReceiverTests(WSTransactionTestCase):
         client = self.connect_as(user)
 
         # create reaction
-        ConversationMessageReaction.objects.create(
-            message=message,
-            user=reaction_user,
-            name='carrot',
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            ConversationMessageReaction.objects.create(
+                message=message,
+                user=reaction_user,
+                name='carrot',
+            )
 
         # check if conversation update was received
         response = client.messages[0]
@@ -457,7 +449,8 @@ class ConversationMessageReactionReceiverTests(WSTransactionTestCase):
         # login and connect
         client = self.connect_as(user)
 
-        reaction.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            reaction.delete()
 
         # check if conversation update was received
         response = client.messages[0]
@@ -515,7 +508,34 @@ class GroupMembershipReceiverTests(WSTestCase):
         joining_client = self.connect_as(self.user)
         nonmember_client = self.connect_as(UserFactory())
 
-        self.group.add_member(self.user)
+        with self.captureOnCommitCallbacks(execute=True):
+            self.group.add_member(self.user)
+
+        self.assertEqual([m['topic'] for m in member_client.messages], [
+            'groups:group_detail',
+            'conversations:conversation',
+            'notifications:notification',
+            'status',
+            'history:history',
+            'groups:group_preview',
+            'groups:user_joined',
+        ])
+
+        self.assertEqual(
+            [m['topic'] for m in joining_client.messages],
+            [
+                'groups:group_detail',
+                'conversations:conversation',
+                'conversations:conversation',  # TODO: seems unnecessary!
+                'history:history',
+                'groups:group_preview',
+                'groups:user_joined',
+            ]
+        )
+
+        self.assertEqual([m['topic'] for m in nonmember_client.messages], [
+            'groups:group_preview',
+        ])
 
         response = member_client.messages_by_topic.get('groups:group_detail')[0]
         self.assertIn(self.user.id, response['payload']['members'])
@@ -540,24 +560,37 @@ class GroupMembershipReceiverTests(WSTestCase):
         self.assertNotIn('memberships', response['payload'])
 
     def test_receive_group_leave_as_leaving_user(self):
+        self.group.add_member(self.user)
         # Clean up notifications from group setup, to prevent notification_deleted messages
         Notification.objects.all().delete()
-        client = self.connect_as(self.member)
+        leave_client = self.connect_as(self.member)
+        stay_client = self.connect_as(self.user)
 
-        self.group.remove_member(self.member)
+        with self.captureOnCommitCallbacks(execute=True):
+            self.group.remove_member(self.member)
 
-        response = client.messages_by_topic.get('groups:group_preview')[0]
-        self.assertFalse(response['payload']['is_member'])
-        self.assertNotIn('memberships', response['payload'])
-        self.assertEqual([m['topic'] for m in client.messages], [
+        self.assertEqual([m['topic'] for m in leave_client.messages], [
             'history:history',
             'conversations:leave',
             'conversations:conversation',
             'status',
             'groups:group_preview',
+            'groups:user_left',
         ])
 
-        status_messages = client.messages_by_topic['status']
+        self.assertEqual([m['topic'] for m in stay_client.messages], [
+            'history:history',
+            'conversations:conversation',
+            'groups:group_detail',
+            'groups:group_preview',
+            'groups:user_left',
+        ])
+
+        response = leave_client.messages_by_topic.get('groups:group_preview')[0]
+        self.assertFalse(response['payload']['is_member'])
+        self.assertNotIn('memberships', response['payload'])
+
+        status_messages = leave_client.messages_by_topic['status']
         self.assertEqual(len(status_messages), 1, status_messages)
         self.assertEqual(
             status_messages[0]['payload'], {
@@ -580,14 +613,14 @@ class GroupMembershipReceiverTests(WSTestCase):
         membership.add_roles([roles.GROUP_EDITOR])
         membership.save()
 
-        response = client.messages_by_topic.get('groups:group_detail')[0]
-        self.assertIn(roles.GROUP_EDITOR, response['payload']['memberships'][self.user.id]['roles'])
-
         self.assertEqual([m['topic'] for m in client.messages], [
             'notifications:notification',
             'status',
             'groups:group_detail',
         ])
+
+        response = client.messages_by_topic.get('groups:group_detail')[0]
+        self.assertIn(roles.GROUP_EDITOR, response['payload']['memberships'][self.user.id]['roles'])
 
 
 class ApplicationReceiverTests(WSTestCase):
@@ -1057,7 +1090,7 @@ class IssueReceiverTest(WSTestCase):
 
 
 @patch('karrot.subscriptions.tasks.notify_subscribers')
-class ReceiverPushTests(TransactionTestCase):
+class ReceiverPushTests(TestCase):
     def setUp(self):
         self.user = UserFactory()
         self.author = UserFactory()
@@ -1077,7 +1110,10 @@ class ReceiverPushTests(TransactionTestCase):
 
     def test_sends_to_push_subscribers(self, notify_subscribers):
         # add a message to the conversation
-        ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
+        with self.captureOnCommitCallbacks(execute=True):
+            ConversationMessage.objects.create(
+                conversation=self.conversation, content=self.content, author=self.author
+            )
 
         self.assertEqual(notify_subscribers.call_count, 2)
         kwargs = notify_subscribers.call_args_list[0][1]
@@ -1086,10 +1122,13 @@ class ReceiverPushTests(TransactionTestCase):
         self.assertEqual(kwargs['fcm_options']['message_body'], self.content)
 
     def test_send_push_notification_if_active_channel_subscription(self, notify_subscribers):
-        # add a channel subscription
-        ChannelSubscription.objects.create(user=self.user, reply_channel='foo')
-        # add a message to the conversation
-        ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
+        with self.captureOnCommitCallbacks(execute=True):
+            # add a channel subscription
+            ChannelSubscription.objects.create(user=self.user, reply_channel='foo')
+            # add a message to the conversation
+            ConversationMessage.objects.create(
+                conversation=self.conversation, content=self.content, author=self.author
+            )
 
         kwargs = notify_subscribers.call_args_list[0][1]
         self.assertEqual(len(kwargs['subscriptions']), 1)
@@ -1097,11 +1136,14 @@ class ReceiverPushTests(TransactionTestCase):
         self.assertEqual(len(kwargs['subscriptions']), 0)
 
     def test_send_push_notification_if_channel_subscription_is_away(self, notify_subscribers):
-        # add a channel subscription to prevent the push being sent
-        ChannelSubscription.objects.create(user=self.user, reply_channel='foo', away_at=timezone.now())
+        with self.captureOnCommitCallbacks(execute=True):
+            # add a channel subscription to prevent the push being sent
+            ChannelSubscription.objects.create(user=self.user, reply_channel='foo', away_at=timezone.now())
 
-        # add a message to the conversation
-        ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
+            # add a message to the conversation
+            ConversationMessage.objects.create(
+                conversation=self.conversation, content=self.content, author=self.author
+            )
 
         self.assertEqual(notify_subscribers.call_count, 2)
         kwargs = notify_subscribers.call_args_list[0][1]
@@ -1111,7 +1153,7 @@ class ReceiverPushTests(TransactionTestCase):
 
 
 @patch('karrot.subscriptions.tasks.notify_subscribers')
-class GroupConversationReceiverPushTests(TransactionTestCase):
+class GroupConversationReceiverPushTests(TestCase):
     def setUp(self):
         self.group = GroupFactory()
         self.user = UserFactory()
@@ -1132,8 +1174,11 @@ class GroupConversationReceiverPushTests(TransactionTestCase):
         )
 
     def test_sends_to_push_subscribers(self, notify_subscribers):
-        # add a message to the conversation
-        ConversationMessage.objects.create(conversation=self.conversation, content=self.content, author=self.author)
+        with self.captureOnCommitCallbacks(execute=True):
+            # add a message to the conversation
+            ConversationMessage.objects.create(
+                conversation=self.conversation, content=self.content, author=self.author
+            )
 
         self.assertEqual(notify_subscribers.call_count, 2)
         kwargs = notify_subscribers.call_args_list[0][1]


### PR DESCRIPTION
`/api/groups-info/` and `/api/bootstrap/` seem to be quite slow (average >400ms) and are called for every app load, so it seems useful to optimize. (https://grafana.karrot.world/d/000000003/requests?orgId=3)

So far, we always delivered a complete list of member ids for every group, because it seemed straightforward and the frontend relies on it. But we already prepared for its removal, by adding `member_count` and `is_member` to GroupPreviewSerializer in #1072.

The endpoint seems slow for two reasons:
1. we always send info about all groups, about 200 on karrot.world (most of them inactive)
2. calculation is done in the serializer, which takes most of the time (as profiled by Silk: database queries are fast)

This PR covers the second issue by removing the member list together with the prefetch query, and adding annotations to shift the work into the database.

This needs frontend support before it can get merged: https://github.com/yunity/karrot-frontend/pull/2383

