### PR TITLE
FCM: prevent cleanup and stats if response seems invalid

### DIFF
--- a/karrot/subscriptions/tests/test_fcm.py
+++ b/karrot/subscriptions/tests/test_fcm.py
@@ -134,3 +134,30 @@ class FCMNotifySubscribersTests(TestCase):
                 },
             },
         ])
+
+    @patch('karrot.subscriptions.stats.write_points')
+    @patch('karrot.subscriptions.fcm.fcm.notify_multiple_devices')
+    def test_prevent_cleanup_and_stats_if_result_count_does_not_match(self, notify_multiple_devices, write_points):
+        # we give it one subscription, and it gives us two responses!?
+        subscription = PushSubscriptionFactory()
+
+        notify_multiple_devices.return_value = {
+            'results': [
+                # not sure if this is can be a real FCM response, but let's just assume the worst case...
+                {
+                    'error': 'InvalidRegistration'
+                },
+                {
+                    'message_id': '123'
+                },
+            ],
+        }
+
+        fcm.notify_subscribers([subscription], {
+            'message_title': 'title',
+            'message_body': '...',
+        })
+
+        write_points.assert_not_called()
+
+        self.assertEqual(PushSubscription.objects.count(), 1)


### PR DESCRIPTION
Adding a quick workaround because I couldn't reproduce the problem.

Related to https://chat.karrot.world/channel/karrot-dev?msg=uTdC7GHhAhi3dZ42k
