### PR TITLE
websocket updates: provide empty request.META for GroupPreviewSerializer

### DIFF
--- a/karrot/groups/serializers.py
+++ b/karrot/groups/serializers.py
@@ -293,7 +293,7 @@ class DistanceField(Field):
     It may return None under various conditions:
     - the GeoIP2 libary was not initialized (missing the files)
     - there is no request context
-    - we cannot detirmine the IP address of the client
+    - we cannot determine the IP address of the client
     - the IP address cannot be found in the database
     """
     def __init__(self, **kwargs):

--- a/karrot/subscriptions/tests/test_receivers.py
+++ b/karrot/subscriptions/tests/test_receivers.py
@@ -463,9 +463,10 @@ class GroupReceiverTests(WSTestCase):
         super().setUp()
         self.member = UserFactory()
         self.user = UserFactory()
-        self.group = GroupFactory(members=[self.member])
+        self.group = GroupFactory(members=[self.member], latitude=48.0, longitude=12.0)
 
-    def test_receive_group_changes(self):
+    @patch('karrot.utils.geoip.geoip')
+    def test_receive_group_changes(self, geoip):
         client = self.connect_as(self.member)
 
         name = faker.name()

--- a/karrot/subscriptions/utils.py
+++ b/karrot/subscriptions/utils.py
@@ -37,6 +37,7 @@ def send_in_channel(channel, topic, payload):
 class MockRequest:
     def __init__(self, user=None):
         self.user = user or AnonymousUser()
+        self.META = {}
 
     def build_absolute_uri(self, path):
         return settings.HOSTNAME + path


### PR DESCRIPTION
By providing a mock `request` object for websocket updates, we got the error of missing `request.META` that is used by `DistanceField`. This PR provides an empty `META` dict as workaround.

Fixes https://sentry.io/organizations/foodsaving-worldwide/issues/2474312378

---

But now that I think about it, we actually might need a proper solution here. This change would set `distance` to `None` when the group update is delivered via websocket, which will mix up the sorting of group gallery.

The problem likely existed before in production, as `request` wasn't set for GroupPreviewSerializer in websocket updates. This PR would restore previous buggy behavior. Currently in production, people would not get group updates via websocket at all.

But maybe it would be better to go in the direction @nicksellen mentioned before, by just telling the frontend "groups have changed" and the frontend will reload them as it pleases. As this is a proper request, it would take the "normal" path with a full request object available.