### PR TITLE
Add env variable to set sentry environment

### DIFF
--- a/config/options.env
+++ b/config/options.env
@@ -101,6 +101,7 @@ INFLUXDB_PASSWORD=
 #-----------------------------------------------
 
 SENTRY_DSN=
+SENTRY_ENVIRONMENT='production'
 SENTRY_RELEASE=
 SENTRY_RELEASE_USE_GIT_REV=true
 SENTRY_CLIENT_DSN=

--- a/config/settings.py
+++ b/config/settings.py
@@ -408,6 +408,7 @@ INFLUXDB_TIMEOUT = 5
 INFLUXDB_USE_THREADING = True
 
 SENTRY_DSN = options['SENTRY_DSN']
+SENTRY_ENVIRONMENT = options['SENTRY_ENVIRONMENT']
 SENTRY_CLIENT_DSN = options['SENTRY_CLIENT_DSN']
 SENTRY_RELEASE = options['SENTRY_RELEASE']
 
@@ -418,6 +419,7 @@ if SENTRY_DSN:
         traces_sample_rate=0.1,
         send_default_pii=False,
         release=SENTRY_RELEASE,
+        environment=SENTRY_ENVIRONMENT,
     )
 
 SECRET_KEY = options['SECRET_KEY']


### PR DESCRIPTION
Should make it easier to differentiate between seperate deployments using the same DSN, as we have for karrot.world and dev.karrot.world.

I already made [this change](https://github.com/yunity/yuca/commit/2d5bd302165ebb01fd719a8a8e207db0c4b3f05f) in the yuca ansible repo to set SENTRY_ENVIRONMENT to `site`, which should be `karrot-world` and `karrot-dev` for our purposes.