### PR TITLE
rename pickups to activities in notification mail subject

### DIFF
--- a/karrot/activities/templates/activity_notification.subject.jinja2
+++ b/karrot/activities/templates/activity_notification.subject.jinja2
@@ -1,1 +1,1 @@
-[{{ site_name }}] 📆 {% trans group_name=group.name|safe %}{{ group_name }} upcoming pickups{% endtrans %}
+[{{ site_name }}] 📆 {% trans group_name=group.name|safe %}{{ group_name }} upcoming activities{% endtrans %}

--- a/karrot/locale/ar/LC_MESSAGES/django.po
+++ b/karrot/locale/ar/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/cs/LC_MESSAGES/django.po
+++ b/karrot/locale/cs/LC_MESSAGES/django.po
@@ -120,7 +120,7 @@ msgstr "Klikněte zde pro odhlášení odběru"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s nadcházející vyzvednutí"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/da/LC_MESSAGES/django.po
+++ b/karrot/locale/da/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/de/LC_MESSAGES/django.po
+++ b/karrot/locale/de/LC_MESSAGES/django.po
@@ -126,7 +126,7 @@ msgstr "Klicke hier um dich auszutragen"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s, anstehende Abholungen"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/el/LC_MESSAGES/django.po
+++ b/karrot/locale/el/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -59,6 +59,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.html.jinja2:6
 #: karrot/activities/templates/activity_notification.html.jinja2:192
+#: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
 msgid "%(group_name)s upcoming activities"
 msgstr ""
@@ -109,11 +110,6 @@ msgstr ""
 #: karrot/issues/templates/new_conflict_resolution.html.jinja2:219
 #: karrot/offers/templates/new_offer.html.jinja2:232
 msgid "Click here to unsubscribe"
-msgstr ""
-
-#: karrot/activities/templates/activity_notification.subject.jinja2:1
-#, python-format
-msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/eo/LC_MESSAGES/django.po
+++ b/karrot/locale/eo/LC_MESSAGES/django.po
@@ -119,7 +119,7 @@ msgstr "Alklaku ĉi tie por malaboni"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)sbaldaŭaj savadoj"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/es/LC_MESSAGES/django.po
+++ b/karrot/locale/es/LC_MESSAGES/django.po
@@ -124,7 +124,7 @@ msgstr "Click aquí para darte de baja"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "Recogidas futuras de %(group_name)s"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/fa/LC_MESSAGES/django.po
+++ b/karrot/locale/fa/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/fa_IR/LC_MESSAGES/django.po
+++ b/karrot/locale/fa_IR/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/fr/LC_MESSAGES/django.po
+++ b/karrot/locale/fr/LC_MESSAGES/django.po
@@ -122,7 +122,7 @@ msgstr "Clique ici pour te désabonner"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)srécoltes à venir"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/gu/LC_MESSAGES/django.po
+++ b/karrot/locale/gu/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/he_IL/LC_MESSAGES/django.po
+++ b/karrot/locale/he_IL/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/hi/LC_MESSAGES/django.po
+++ b/karrot/locale/hi/LC_MESSAGES/django.po
@@ -118,7 +118,7 @@ msgstr "सदस्यता समाप्त करने के लिए �
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s आगामी पिकअप"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/hr/LC_MESSAGES/django.po
+++ b/karrot/locale/hr/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/hu/LC_MESSAGES/django.po
+++ b/karrot/locale/hu/LC_MESSAGES/django.po
@@ -119,7 +119,7 @@ msgstr "Kattints ide a leiratkozáshoz"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s közelgő felvételek"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/it/LC_MESSAGES/django.po
+++ b/karrot/locale/it/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/ja/LC_MESSAGES/django.po
+++ b/karrot/locale/ja/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/lb/LC_MESSAGES/django.po
+++ b/karrot/locale/lb/LC_MESSAGES/django.po
@@ -119,7 +119,7 @@ msgstr "Klick hei fir dech ze desabonéieren"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "Zukünfteg Ofhuelungen vu %(group_name)s"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/mr/LC_MESSAGES/django.po
+++ b/karrot/locale/mr/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/nl/LC_MESSAGES/django.po
+++ b/karrot/locale/nl/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/no/LC_MESSAGES/django.po
+++ b/karrot/locale/no/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/pl/LC_MESSAGES/django.po
+++ b/karrot/locale/pl/LC_MESSAGES/django.po
@@ -119,7 +119,7 @@ msgstr "Kliknij, aby zrezygnować z subskrypcji"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "Nadchodzące odbiory w %(group_name)s"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/pt/LC_MESSAGES/django.po
+++ b/karrot/locale/pt/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/pt_BR/LC_MESSAGES/django.po
+++ b/karrot/locale/pt_BR/LC_MESSAGES/django.po
@@ -120,7 +120,7 @@ msgstr "Clique aqui para se desinscrever"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/ro/LC_MESSAGES/django.po
+++ b/karrot/locale/ro/LC_MESSAGES/django.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/ru/LC_MESSAGES/django.po
+++ b/karrot/locale/ru/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/sv/LC_MESSAGES/django.po
+++ b/karrot/locale/sv/LC_MESSAGES/django.po
@@ -118,7 +118,7 @@ msgstr "Klicka här för att avregistrera prenumerationen"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "kommande upphämtningar i %(group_name)s"
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/yo/LC_MESSAGES/django.po
+++ b/karrot/locale/yo/LC_MESSAGES/django.po
@@ -328,7 +328,7 @@ msgstr ""
 #: foodsaving/pickups/templates/pickup_notification.html.jinja2:130
 #: foodsaving/pickups/templates/pickup_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr ""
 
 #: foodsaving/pickups/templates/pickup_notification.html.jinja2:134

--- a/karrot/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/karrot/locale/zh_Hans/LC_MESSAGES/django.po
@@ -117,7 +117,7 @@ msgstr "點擊以取消訂閱"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s的新領取任務 ! "
 
 #: karrot/applications/api.py:27

--- a/karrot/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/karrot/locale/zh_Hant/LC_MESSAGES/django.po
@@ -118,7 +118,7 @@ msgstr "點擊以取消訂閱"
 
 #: karrot/activities/templates/activity_notification.subject.jinja2:1
 #, python-format
-msgid "%(group_name)s upcoming pickups"
+msgid "%(group_name)s upcoming activities"
 msgstr "%(group_name)s的新領取任務 ! "
 
 #: karrot/applications/api.py:27


### PR DESCRIPTION
I have fixed the notification e-mail subject. See https://github.com/yunity/karrot-frontend/issues/2425.

Do I need to update all occurrences in the *.po localization files as well or will a script take care of this after the pull request is merged?