### PR TITLE
Allow to join started (but not finished) activity

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -20,7 +20,7 @@ from karrot.activities.models import (
 )
 from karrot.activities.permissions import (
     IsUpcoming, HasNotJoinedActivity, HasJoinedActivity, IsEmptyActivity, IsNotFull, IsSameParticipant,
-    IsRecentActivity, IsGroupEditor, TypeHasNoActivities, CannotChangeGroup, IsNotUpcoming
+    IsRecentActivity, IsGroupEditor, TypeHasNoActivities, CannotChangeGroup, IsNotUpcoming, IsNotPast
 )
 from karrot.activities.serializers import (
     ActivityDismissFeedbackSerializer, ActivitySerializer, ActivitySeriesSerializer, ActivityJoinSerializer,
@@ -227,7 +227,7 @@ class ActivityViewSet(
     @action(
         detail=True,
         methods=['POST'],
-        permission_classes=(IsAuthenticated, IsUpcoming, HasNotJoinedActivity, IsNotFull),
+        permission_classes=(IsAuthenticated, IsNotPast, HasNotJoinedActivity, IsNotFull),
         serializer_class=ActivityJoinSerializer
     )
     def add(self, request, pk=None):
@@ -238,7 +238,7 @@ class ActivityViewSet(
     @action(
         detail=True,
         methods=['POST'],
-        permission_classes=(IsAuthenticated, IsUpcoming, HasJoinedActivity),
+        permission_classes=(IsAuthenticated, IsNotPast, HasJoinedActivity),
         serializer_class=ActivityLeaveSerializer
     )
     def remove(self, request, pk=None):

--- a/karrot/activities/models.py
+++ b/karrot/activities/models.py
@@ -343,7 +343,7 @@ class Activity(BaseModel, ConversationMixin):
 
     @property
     def ended_at(self):
-        if self.is_upcoming():
+        if self.is_not_past():
             return None
         return self.date.end
 
@@ -362,6 +362,12 @@ class Activity(BaseModel, ConversationMixin):
 
     def is_upcoming(self):
         return self.date.start > timezone.now()
+
+    def is_past(self):
+        return self.date.end < timezone.now()
+
+    def is_not_past(self):
+        return not self.is_past()
 
     def is_full(self):
         if not self.max_participants:

--- a/karrot/activities/permissions.py
+++ b/karrot/activities/permissions.py
@@ -2,8 +2,19 @@ from django.conf import settings
 from rest_framework import permissions
 
 
-class IsUpcoming(permissions.BasePermission):
+class IsNotPast(permissions.BasePermission):
     message = 'The activity is in the past.'
+
+    def has_object_permission(self, request, view, obj):
+        # do allow GETs for activities in the past
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        else:
+            return obj.is_not_past()
+
+
+class IsUpcoming(permissions.BasePermission):
+    message = 'The activity is not upcoming.'
 
     def has_object_permission(self, request, view, obj):
         # do allow GETs for activities in the past


### PR DESCRIPTION
Fixes https://github.com/yunity/karrot-frontend/issues/2426

This is backend work to allow to join activities that have started, but not finished yet.

The frontend might want to show a warning for this case.

This is minimal implementation that will improve the current situation, other things could be:
- require an extra "confirm" parameter to allow joining ongoing activities
- record in the activity participant that they joined after the start

Also, I noticed other places, around the feedback, where "past" is considered as "before started" rather than "after finished". But I did not touch those areas.