### PR TITLE
Password Policy for New Users

### DIFF
--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -735,9 +735,9 @@ msgstr ""
 msgid "You are already subscribed to this place"
 msgstr ""
 
-#: karrot/userauth/api.py:98 karrot/userauth/serializers.py:94
-#: karrot/userauth/serializers.py:143 karrot/userauth/serializers.py:164
-#: karrot/userauth/serializers.py:194 karrot/userauth/serializers.py:216
+#: karrot/userauth/api.py:98 karrot/userauth/serializers.py:104
+#: karrot/userauth/serializers.py:153 karrot/userauth/serializers.py:174
+#: karrot/userauth/serializers.py:204 karrot/userauth/serializers.py:226
 msgid "We could not send you an e-mail."
 msgstr ""
 
@@ -745,27 +745,27 @@ msgstr ""
 msgid "Mail is already verified."
 msgstr ""
 
-#: karrot/userauth/serializers.py:24
+#: karrot/userauth/serializers.py:27
 msgid "Unable to log in with provided credentials."
 msgstr ""
 
-#: karrot/userauth/serializers.py:81 karrot/userauth/serializers.py:181
+#: karrot/userauth/serializers.py:91 karrot/userauth/serializers.py:191
 msgid "Similar e-mail exists: "
 msgstr ""
 
-#: karrot/userauth/serializers.py:118
+#: karrot/userauth/serializers.py:128
 msgid "Verification code is invalid"
 msgstr ""
 
-#: karrot/userauth/serializers.py:122
+#: karrot/userauth/serializers.py:132
 msgid "Verification code has expired"
 msgstr ""
 
-#: karrot/userauth/serializers.py:157 karrot/userauth/serializers.py:175
+#: karrot/userauth/serializers.py:167 karrot/userauth/serializers.py:185
 msgid "Wrong password"
 msgstr ""
 
-#: karrot/userauth/serializers.py:208
+#: karrot/userauth/serializers.py:218
 msgid "Unknown e-mail address"
 msgstr ""
 
@@ -914,7 +914,7 @@ msgid ""
 "service using this email address."
 msgstr ""
 
-#: karrot/utils/validators.py:8
+#: karrot/utils/validators.py:18
 #, python-format
 msgid "%(value)s is a reserved name"
 msgstr ""

--- a/karrot/management/commands/create_sample_data.py
+++ b/karrot/management/commands/create_sample_data.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
             print('login as', u)
             return u
 
-        default_password = '123'
+        default_password = 'K@rr0t1!'
 
         def make_user(verified=True):
             response = c.post(

--- a/karrot/userauth/serializers.py
+++ b/karrot/userauth/serializers.py
@@ -7,8 +7,11 @@ from versatileimagefield.serializers import VersatileImageFieldSerializer
 
 from karrot.userauth import stats
 from karrot.userauth.models import VerificationCode
-from karrot.utils.validators import prevent_reserved_names
 from karrot.webhooks.models import EmailEvent
+from karrot.utils.validators import (
+    prevent_reserved_names, contains_number, contains_lowercase_letter, contains_uppercase_letter,
+    contains_special_character, prevent_use_of_company_name, password_not_blacklisted
+)
 
 
 class AuthLoginSerializer(serializers.Serializer):
@@ -56,7 +59,14 @@ class AuthUserSerializer(serializers.ModelSerializer):
                 'validators': [prevent_reserved_names],
             },
             'password': {
-                'write_only': True,
+                'write_only':
+                True,
+                'min_length':
+                8,
+                'validators': [
+                    contains_number, contains_lowercase_letter, contains_uppercase_letter, contains_special_character,
+                    prevent_use_of_company_name, password_not_blacklisted
+                ]
             },
             'description': {
                 'trim_whitespace': False,

--- a/karrot/utils/validators.py
+++ b/karrot/utils/validators.py
@@ -1,8 +1,48 @@
+import re
+
 from django.conf import settings
 from rest_framework import serializers
 from django.utils.translation import gettext as _
+
+PASSWORD_BLACKLIST = [
+    'P@ssw0rd', 'ka_dJKHJsy6', '1qaz!QAZ', '!QAZ2wsx', '1qaz@WSX', '!QAZ1qaz', 'fxzZ75$yer', 'Pa$$w0rd', 'Aug!272010',
+    'L58jkdjP!m', 'ZV_!80lo', 'P@$$w0rd', 'ZAQ!2wsx', 'zaq1@WSX', 'g00dPa$$w0rD', 'Password1!', '!QAZxsw2', '1qazZAQ!',
+    'Feder_1941', 'P@ssword1', 'P@55w0rd', '1qazXSW@', '$HEX[687474703a2f2f616473]', 'India@123', 'friendofEarning$1',
+    '$HEX[687474703a2f2f777777]', 'Sym_cskill1', 't4_Us3r', 'Abc123456!', 'friendofYOUCANMAKE$200-', 'P@55word',
+    'Password@123'
+]
 
 
 def prevent_reserved_names(value):
     if value.lower() in settings.RESERVED_NAMES:
         raise serializers.ValidationError(_('%(value)s is a reserved name') % {'value': value})
+
+
+def contains_number(value):
+    if re.search(r'\d', value) is None:
+        raise serializers.ValidationError('password does not contain a number')
+
+
+def contains_lowercase_letter(value):
+    if re.search('[a-z]', value) is None:
+        raise serializers.ValidationError('password does not contain a lowercase letter')
+
+
+def contains_uppercase_letter(value):
+    if re.search('[A-Z]', value) is None:
+        raise serializers.ValidationError('password does not contain an uppercase letter')
+
+
+def contains_special_character(value):
+    if re.search('[@_!#$%^&*()<>?/}{~:|]', value) is None:
+        raise serializers.ValidationError('password does not contain a special character')
+
+
+def prevent_use_of_company_name(value):
+    if re.search('karrot', value.lower()):
+        raise serializers.ValidationError('password cannot contain company name')
+
+
+def password_not_blacklisted(value):
+    if value in PASSWORD_BLACKLIST:
+        raise serializers.ValidationError('password is blacklisted')


### PR DESCRIPTION
Frontend PR: [karrot-dev/karrot-frontend#2436](https://github.com/karrot-dev/karrot-frontend/issues/2436)

Hello! Submitting this PR to get the backend code for the password policy out there! Please let me know what needs to be fixed and how the continuation of this PR (the frontend) should be completed in tandem with this PR. Thank you

Password Validation Specifics:
- Minimum length of 8 characters
- Must use at least one number
- Must use at least one lowercase letter
- Must use at least one uppercase letter
- Must use at least one special character
- Cannot contain any form of the string "karrot"
- Cannot match a blacklisted password

Note: The "blacklisted" passwords were obtained by [here](https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt) and filtered by the previous criteria to only match against blacklisted passwords that also have a minimum length of 8 characters, contain at least one number, etc.

Other Concerns:
- To ensure the correctness of previous usage of passwords I had to change the default password for seed data from `123` to `K@rr0t1!`. Wasn't sure what would be best, but that password fits our criteria